### PR TITLE
Add 30s timeout to all outbound HTTP requests (#56)

### DIFF
--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const { HTTP_TIMEOUT_MS } = require('./viessmann-helpers');
 
 // Token refresh buffer time (5 minutes before expiration)
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
@@ -141,7 +142,8 @@ module.exports = function(RED) {
                 }), {
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded'
-                    }
+                    },
+                    timeout: HTTP_TIMEOUT_MS
                 });
                 
                 // Update tokens in both node and credentials for persistence

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -10,6 +10,13 @@ const axios = require('axios');
 const VIESSMANN_API_BASE_URL = 'https://api.viessmann-climatesolutions.com';
 
 /**
+ * Default HTTP request timeout in milliseconds.
+ * Bounds every outgoing axios call so a hung connection surfaces as an error
+ * instead of blocking the Node-RED flow indefinitely.
+ */
+const HTTP_TIMEOUT_MS = 30000;
+
+/**
  * Initialize a Viessmann node with common setup
  * @param {object} RED - The Node-RED runtime
  * @param {object} node - The Node-RED node instance (this)
@@ -260,7 +267,8 @@ async function executeApiGet(node, msg, url, statusText = 'fetching...', errorPr
                 headers: {
                     'Authorization': `Bearer ${token}`,
                     'Accept': 'application/json'
-                }
+                },
+                timeout: HTTP_TIMEOUT_MS
             });
         });
         
@@ -299,7 +307,8 @@ async function executeApiPost(node, msg, url, data, statusText = 'writing...', e
                     'Authorization': `Bearer ${token}`,
                     'Content-Type': 'application/json',
                     'Accept': 'application/json'
-                }
+                },
+                timeout: HTTP_TIMEOUT_MS
             });
         });
         
@@ -316,6 +325,7 @@ async function executeApiPost(node, msg, url, data, statusText = 'writing...', e
 
 module.exports = {
     VIESSMANN_API_BASE_URL,
+    HTTP_TIMEOUT_MS,
     initializeViessmannNode,
     validateConfigNode,
     createStatusUpdater,

--- a/scripts/get-viessmann-tokens.js
+++ b/scripts/get-viessmann-tokens.js
@@ -15,6 +15,9 @@ const http = require('http');
 const https = require('https');
 const querystring = require('querystring');
 
+// Bound the token-exchange request so a hung connection doesn't leave the script waiting forever.
+const HTTP_TIMEOUT_MS = 30000;
+
 const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -103,11 +106,11 @@ function exchangeCodeForTokens(clientId, code, codeVerifier, redirectUri) {
         
         const req = https.request(options, (res) => {
             let data = '';
-            
+
             res.on('data', (chunk) => {
                 data += chunk;
             });
-            
+
             res.on('end', () => {
                 try {
                     const response = JSON.parse(data);
@@ -121,11 +124,15 @@ function exchangeCodeForTokens(clientId, code, codeVerifier, redirectUri) {
                 }
             });
         });
-        
+
         req.on('error', (err) => {
             reject(err);
         });
-        
+
+        req.setTimeout(HTTP_TIMEOUT_MS, () => {
+            req.destroy(new Error(`Token exchange timed out after ${HTTP_TIMEOUT_MS}ms`));
+        });
+
         req.write(postData);
         req.end();
     });

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const {
     VIESSMANN_API_BASE_URL,
+    HTTP_TIMEOUT_MS,
     extractErrorMessage,
     truncateForStatus,
     validateInstallationId,
@@ -14,6 +15,14 @@ describe('viessmann-helpers', function() {
     describe('VIESSMANN_API_BASE_URL', function() {
         it('should be the correct Viessmann API base URL', function() {
             expect(VIESSMANN_API_BASE_URL).to.equal('https://api.viessmann-climatesolutions.com');
+        });
+    });
+
+    describe('HTTP_TIMEOUT_MS', function() {
+        it('should be a positive integer suitable for axios timeout', function() {
+            expect(HTTP_TIMEOUT_MS).to.be.a('number');
+            expect(HTTP_TIMEOUT_MS).to.be.greaterThan(0);
+            expect(Number.isInteger(HTTP_TIMEOUT_MS)).to.equal(true);
         });
     });
 


### PR DESCRIPTION
Closes #56.

## Summary
- Adds `HTTP_TIMEOUT_MS = 30000` in `viessmann-helpers.js` (exported).
- Threads it into `executeApiGet`, `executeApiPost`, and `refreshAccessToken`.
- Adds an equivalent `req.setTimeout` in `scripts/get-viessmann-tokens.js` so the PKCE bootstrap doesn't hang on a stalled token endpoint either.
- One smoke-test asserting the constant is exported and shaped like a valid axios timeout.

## Why
The original report (#56) noted that a dropped connection or unresponsive load-balancer would leave a Node-RED flow's input handler waiting forever — status stuck on "fetching…" with no Catch-node firing.

## Internal multi-perspective review
- **Code quality** — single shared constant, no duplication in runtime code, lint clean.
- **Architecture** — minimal surface change; will live naturally on a future `ViessmannClient` (#58).
- **Security** — does not change auth/TLS/secret handling.
- **Error handling** — axios surfaces a timeout as `error.message = "timeout of 30000ms exceeded"`, which `extractErrorMessage` already propagates to `node.error(...)`. The PKCE script's `req.destroy(err)` triggers `req.on('error')` and rejects the promise cleanly.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 130 passing (was 129)