### PR TITLE
Dedupe concurrent token refreshes (#57)

### DIFF
--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -116,69 +116,88 @@ module.exports = function(RED) {
             throw new Error(errorMsg);
         };
         
+        // In-flight refresh promise. While set, concurrent callers share it
+        // so we never POST /idp/v3/token twice with the same (rotating) refresh
+        // token - the IdP would reject the losers and we'd race-overwrite
+        // node.refreshToken with a stale value.
+        node._refreshPromise = null;
+
         /**
-         * Refresh the access token using refresh token
+         * Refresh the access token using refresh token.
+         * De-duplicates concurrent calls: if a refresh is already in flight,
+         * all callers await the same promise.
          * @returns {Promise<void>}
          */
-        this.refreshAccessToken = async function() {
-            if (!node.refreshToken) {
-                debugLog('No refresh token available, cannot refresh');
-                const errorMsg = 'Access token expired and no refresh token available. Please generate new tokens.';
-                node.error(errorMsg);
-                updateAuthState('error', errorMsg);
-                throw new Error(errorMsg);
+        this.refreshAccessToken = function() {
+            if (node._refreshPromise) {
+                debugLog('Refresh already in flight, awaiting existing request');
+                return node._refreshPromise;
             }
-            
-            try {
-                updateAuthState('authenticating');
-                debugLog('Starting token refresh');
-                debugLog('Current refresh token: ' + maskSensitiveData(node.refreshToken));
-                debugLog('Client ID: ' + maskSensitiveData(node.credentials.clientId));
-                
-                const response = await axios.post(node.tokenUrl, new URLSearchParams({
-                    grant_type: 'refresh_token',
-                    client_id: node.credentials.clientId,
-                    refresh_token: node.refreshToken
-                }), {
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded'
-                    },
-                    timeout: HTTP_TIMEOUT_MS
-                });
-                
-                // Update tokens in both node and credentials for persistence
-                node.accessToken = response.data.access_token;
-                node.credentials.accessToken = response.data.access_token;
-                debugLog('Updated access token in credentials for persistence: ' + maskSensitiveData(response.data.access_token));
-                if (response.data.refresh_token) {
-                    node.refreshToken = response.data.refresh_token;
-                    node.credentials.refreshToken = response.data.refresh_token;
-                    debugLog('Updated refresh token in credentials for persistence: ' + maskSensitiveData(response.data.refresh_token));
+
+            node._refreshPromise = (async function doRefresh() {
+                if (!node.refreshToken) {
+                    debugLog('No refresh token available, cannot refresh');
+                    const errorMsg = 'Access token expired and no refresh token available. Please generate new tokens.';
+                    node.error(errorMsg);
+                    updateAuthState('error', errorMsg);
+                    throw new Error(errorMsg);
                 }
-                node.tokenExpiry = Date.now() + (response.data.expires_in * 1000);
-                
-                const expiryDate = new Date(node.tokenExpiry);
-                debugLog('Token refresh successful');
-                debugLog('New access token: ' + maskSensitiveData(node.accessToken));
-                if (response.data.refresh_token) {
-                    debugLog('New refresh token: ' + maskSensitiveData(node.refreshToken));
+
+                try {
+                    updateAuthState('authenticating');
+                    debugLog('Starting token refresh');
+                    debugLog('Current refresh token: ' + maskSensitiveData(node.refreshToken));
+                    debugLog('Client ID: ' + maskSensitiveData(node.credentials.clientId));
+
+                    const response = await axios.post(node.tokenUrl, new URLSearchParams({
+                        grant_type: 'refresh_token',
+                        client_id: node.credentials.clientId,
+                        refresh_token: node.refreshToken
+                    }), {
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded'
+                        },
+                        timeout: HTTP_TIMEOUT_MS
+                    });
+
+                    // Update tokens in both node and credentials for persistence
+                    node.accessToken = response.data.access_token;
+                    node.credentials.accessToken = response.data.access_token;
+                    debugLog('Updated access token in credentials for persistence: ' + maskSensitiveData(response.data.access_token));
+                    if (response.data.refresh_token) {
+                        node.refreshToken = response.data.refresh_token;
+                        node.credentials.refreshToken = response.data.refresh_token;
+                        debugLog('Updated refresh token in credentials for persistence: ' + maskSensitiveData(response.data.refresh_token));
+                    }
+                    node.tokenExpiry = Date.now() + (response.data.expires_in * 1000);
+
+                    const expiryDate = new Date(node.tokenExpiry);
+                    debugLog('Token refresh successful');
+                    debugLog('New access token: ' + maskSensitiveData(node.accessToken));
+                    if (response.data.refresh_token) {
+                        debugLog('New refresh token: ' + maskSensitiveData(node.refreshToken));
+                    }
+                    debugLog('Token expires in: ' + response.data.expires_in + ' seconds (' + expiryDate.toISOString() + ')');
+
+                    node.log('Successfully refreshed access token and updated credentials');
+                    updateAuthState('authenticated');
+                } catch (error) {
+                    debugLog('Token refresh failed with error: ' + error.message);
+                    if (error.response) {
+                        debugLog('Error status: ' + error.response.status);
+                        debugLog('Error data: ' + JSON.stringify(error.response.data));
+                    }
+                    const errorMsg = error.response?.data?.error_description || error.message;
+                    const fullErrorMsg = 'Token refresh failed: ' + errorMsg + '. You may need to generate new tokens.';
+                    node.error(fullErrorMsg);
+                    updateAuthState('error', fullErrorMsg);
+                    throw error;
                 }
-                debugLog('Token expires in: ' + response.data.expires_in + ' seconds (' + expiryDate.toISOString() + ')');
-                
-                node.log('Successfully refreshed access token and updated credentials');
-                updateAuthState('authenticated');
-            } catch (error) {
-                debugLog('Token refresh failed with error: ' + error.message);
-                if (error.response) {
-                    debugLog('Error status: ' + error.response.status);
-                    debugLog('Error data: ' + JSON.stringify(error.response.data));
-                }
-                const errorMsg = error.response?.data?.error_description || error.message;
-                const fullErrorMsg = 'Token refresh failed: ' + errorMsg + '. You may need to generate new tokens.';
-                node.error(fullErrorMsg);
-                updateAuthState('error', fullErrorMsg);
-                throw error;
-            }
+            })().finally(() => {
+                node._refreshPromise = null;
+            });
+
+            return node._refreshPromise;
         };
         
         /**

--- a/test/viessmann-config_spec.js
+++ b/test/viessmann-config_spec.js
@@ -73,6 +73,55 @@ describe('viessmann-config Node', function() {
         });
     });
 
+    it('should dedupe concurrent token refreshes into a single token endpoint call', function(done) {
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
+            name: 'test config'
+        }];
+        const credentials = {
+            n1: {
+                clientId: 'test-client-id',
+                accessToken: 'initial-token',
+                refreshToken: 'initial-refresh-token'
+            }
+        };
+
+        // Allow up to 5 refresh calls but track how many actually fire.
+        // Without de-duplication, three concurrent refreshAccessToken()
+        // calls would trigger three POSTs - and the IdP would invalidate
+        // the rotating refresh_token after the first.
+        let postCount = 0;
+        nock('https://iam.viessmann-climatesolutions.com')
+            .post('/idp/v3/token')
+            .times(5)
+            .reply(200, () => {
+                postCount += 1;
+                return {
+                    access_token: 'refreshed-token-' + postCount,
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                    refresh_token: 'rotated-refresh-' + postCount
+                };
+            });
+
+        helper.load(configNode, flow, credentials, function() {
+            const n1 = helper.getNode('n1');
+
+            Promise.all([
+                n1.refreshAccessToken(),
+                n1.refreshAccessToken(),
+                n1.refreshAccessToken()
+            ]).then(() => {
+                expect(postCount).to.equal(1);
+                // All three callers should see the same single-rotation result.
+                expect(n1.accessToken).to.equal('refreshed-token-1');
+                expect(n1.refreshToken).to.equal('rotated-refresh-1');
+                done();
+            }).catch(done);
+        });
+    });
+
     it('should refresh token when expired', function(done) {
         const flow = [{ 
             id: 'n1', 


### PR DESCRIPTION
Closes #57.

## Summary
- `refreshAccessToken` memoizes its in-flight promise on `node._refreshPromise`. Concurrent callers share the single POST. The promise is cleared in `.finally()`.
- Adds a regression test: three concurrent `refreshAccessToken()` calls produce exactly one POST to `/idp/v3/token`.

## Why
The original report (#57) noted that without de-dup, IdPs that rotate `refresh_token` invalidate all losers (`invalid_grant`), and the racing assignments to `node.refreshToken` overwrite a fresh value with a stale one — leaving the integration unauthenticated until tokens are regenerated.

## Internal multi-perspective review
- **Code quality** — IIFE keeps the body identical; `.finally()` clearing pattern is idiomatic.
- **Architecture** — memo lives on the config node where auth state lives; will fold cleanly into a future `ViessmannClient` (#58).
- **Security** — closes a token-rotation race observed under normal multi-node usage.
- **Error handling** — on failure, `node.error` is now called once per refresh attempt (was N for N concurrent callers), and all callers reject with the same error.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 131 passing (was 130). New test asserts `postCount === 1` after three concurrent refreshes.