### PR TITLE
Extract ViessmannClient HTTP/auth/retry layer (#58)

### DIFF
--- a/nodes/lib/client.js
+++ b/nodes/lib/client.js
@@ -1,0 +1,162 @@
+/**
+ * ViessmannClient - HTTP client for the Viessmann SaaS API.
+ *
+ * Owns the cross-cutting concerns that previously leaked into helpers:
+ *   - axios instance with baseURL, timeout, default headers
+ *   - token retrieval and 401-triggered refresh-and-retry
+ *   - transient-failure retry (429 with Retry-After, 5xx with bounded backoff)
+ *
+ * UI concerns (node.status, node.error) stay in the per-node wrappers
+ * (executeApiGet/executeApiPost in viessmann-helpers.js). The client surfaces
+ * retry timing through an optional onRetryWait callback so the wrapper can
+ * reflect it in the visible node status without coupling the client to
+ * Node-RED-specific APIs.
+ */
+
+const axios = require('axios');
+
+const VIESSMANN_API_BASE_URL = 'https://api.viessmann-climatesolutions.com';
+const HTTP_TIMEOUT_MS = 30000;
+
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+const MAX_RETRIES = 3;
+const BASE_RETRY_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 30000;
+
+/**
+ * Parse an HTTP Retry-After header into milliseconds, or return null if unparseable.
+ * Accepts delta-seconds or HTTP-date.
+ */
+function parseRetryAfter(header) {
+    if (header === undefined || header === null || header === '') {
+        return null;
+    }
+    const seconds = Number(header);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+        return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
+    }
+    const dateMs = Date.parse(header);
+    if (Number.isFinite(dateMs)) {
+        return Math.max(0, Math.min(dateMs - Date.now(), MAX_RETRY_DELAY_MS));
+    }
+    return null;
+}
+
+/**
+ * Exponential backoff with mild jitter to avoid thundering herd.
+ * @param {number} attempt - 1-indexed attempt
+ */
+function backoffDelayMs(attempt) {
+    const jitter = 0.9 + Math.random() * 0.2;
+    return Math.min(BASE_RETRY_DELAY_MS * Math.pow(2, attempt - 1) * jitter, MAX_RETRY_DELAY_MS);
+}
+
+class ViessmannClient {
+    /**
+     * @param {object} configNode - The viessmann-config node (provides getValidToken / refreshAccessToken)
+     * @param {object} [options]
+     * @param {string} [options.baseURL] - Override the API base URL
+     * @param {number} [options.timeout] - Per-request timeout in ms
+     * @param {number} [options.maxRetries] - Cap on transient-failure retries
+     * @param {object} [options.axiosInstance] - Inject a pre-built axios instance (testing)
+     * @param {Function} [options.log] - Debug logger; defaults to noop
+     */
+    constructor(configNode, options = {}) {
+        this._config = configNode;
+        this._baseURL = options.baseURL || VIESSMANN_API_BASE_URL;
+        this._timeout = options.timeout || HTTP_TIMEOUT_MS;
+        this._maxRetries = options.maxRetries ?? MAX_RETRIES;
+        this._log = typeof options.log === 'function' ? options.log : () => {};
+        this._axios = options.axiosInstance || axios.create({
+            baseURL: this._baseURL,
+            timeout: this._timeout,
+            headers: { 'Accept': 'application/json' }
+        });
+    }
+
+    /**
+     * GET request. url may be absolute (baseURL ignored by axios) or a path.
+     * @param {string} url
+     * @param {object} [options]
+     * @param {Function} [options.onRetryWait] - Called as ({status, attempt, delayMs}) before each retry sleep.
+     */
+    get(url, options = {}) {
+        return this._request({ method: 'GET', url }, options);
+    }
+
+    /**
+     * POST request.
+     * @param {string} url
+     * @param {*} data - request body
+     * @param {object} [options]
+     */
+    post(url, data, options = {}) {
+        return this._request({
+            method: 'POST',
+            url,
+            data,
+            headers: { 'Content-Type': 'application/json' }
+        }, options);
+    }
+
+    async _request(axiosConfig, { onRetryWait } = {}) {
+        return this._withRetry(() => this._withTokenRefresh(async () => {
+            const token = await this._config.getValidToken();
+            return this._axios.request({
+                ...axiosConfig,
+                headers: { ...(axiosConfig.headers || {}), Authorization: `Bearer ${token}` }
+            });
+        }), onRetryWait);
+    }
+
+    async _withTokenRefresh(requestFn) {
+        try {
+            return await requestFn();
+        } catch (error) {
+            if (error.response && error.response.status === 401) {
+                this._log('Received 401 - refreshing token and retrying');
+                try {
+                    await this._config.refreshAccessToken();
+                    return await requestFn();
+                } catch (refreshError) {
+                    this._log(`Token refresh failed: ${refreshError.message}`);
+                    throw error;
+                }
+            }
+            throw error;
+        }
+    }
+
+    async _withRetry(requestFn, onRetryWait) {
+        for (let attempt = 0; ; attempt++) {
+            try {
+                return await requestFn();
+            } catch (error) {
+                const status = error.response?.status;
+                if (!RETRYABLE_STATUSES.has(status) || attempt >= this._maxRetries) {
+                    throw error;
+                }
+                const nextAttempt = attempt + 1;
+                const retryAfterMs = status === 429
+                    ? parseRetryAfter(error.response.headers?.['retry-after'])
+                    : null;
+                const delayMs = retryAfterMs ?? backoffDelayMs(nextAttempt);
+                if (typeof onRetryWait === 'function') {
+                    onRetryWait({ status, attempt: nextAttempt, delayMs });
+                }
+                this._log(`HTTP ${status} - retrying in ${delayMs}ms (attempt ${nextAttempt}/${this._maxRetries})`);
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+            }
+        }
+    }
+}
+
+module.exports = {
+    ViessmannClient,
+    VIESSMANN_API_BASE_URL,
+    HTTP_TIMEOUT_MS,
+    RETRYABLE_STATUSES,
+    MAX_RETRIES,
+    parseRetryAfter,
+    backoffDelayMs
+};

--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { HTTP_TIMEOUT_MS } = require('./viessmann-helpers');
+const { ViessmannClient, HTTP_TIMEOUT_MS } = require('./lib/client');
 
 // Token refresh buffer time (5 minutes before expiration)
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
@@ -42,6 +42,13 @@ module.exports = function(RED) {
         
         // List of dependent nodes
         this.dependentNodes = [];
+
+        // Shared HTTP client. Owns the axios instance, retry policy, and 401
+        // refresh-and-retry. Per-node wrappers (viessmann-helpers.js) layer
+        // status icon and node.error on top.
+        this.client = new ViessmannClient(node, {
+            log: (m) => debugLog(m)
+        });
         
         /**
          * Log debug information if debug mode is enabled

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -1,29 +1,19 @@
 /**
- * Helper functions for Viessmann nodes
+ * Helper functions for Viessmann nodes.
+ *
+ * Transport, token refresh, and retry policy live on `node.config.client`
+ * (the ViessmannClient instance in nodes/lib/client.js). This file keeps the
+ * Node-RED UI surface: status icons, error surfacing, input validators, node
+ * lifecycle.
  */
 
-const axios = require('axios');
-
-/**
- * Viessmann API base URL constant
- */
-const VIESSMANN_API_BASE_URL = 'https://api.viessmann-climatesolutions.com';
-
-/**
- * Default HTTP request timeout in milliseconds.
- * Bounds every outgoing axios call so a hung connection surfaces as an error
- * instead of blocking the Node-RED flow indefinitely.
- */
-const HTTP_TIMEOUT_MS = 30000;
-
-/**
- * Retry policy for transient API failures. 429 honours Retry-After; the rest
- * use a bounded exponential backoff (1s, 2s, 4s, capped at MAX_RETRY_DELAY_MS).
- */
-const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
-const MAX_RETRIES = 3;
-const BASE_RETRY_DELAY_MS = 1000;
-const MAX_RETRY_DELAY_MS = 30000;
+const {
+    VIESSMANN_API_BASE_URL,
+    HTTP_TIMEOUT_MS,
+    RETRYABLE_STATUSES,
+    MAX_RETRIES,
+    parseRetryAfter
+} = require('./lib/client');
 
 /**
  * Initialize a Viessmann node with common setup
@@ -256,127 +246,33 @@ function validateDeviceId(node, msg) {
 }
 
 /**
- * Parse an HTTP Retry-After header value into milliseconds, or return null if unparseable.
- * Accepts either a delta-seconds number or an HTTP-date.
- * @param {string|undefined} header - The Retry-After header value
- * @returns {number|null} Milliseconds to wait, or null if the header is missing/invalid.
+ * Build a retry-wait callback that reflects the next retry's countdown in the
+ * node's status icon, so users see "fetching... (HTTP 429, retry in 2s)"
+ * instead of a frozen yellow ring.
  */
-function parseRetryAfter(header) {
-    if (header === undefined || header === null || header === '') {
-        return null;
-    }
-    const seconds = Number(header);
-    if (Number.isFinite(seconds) && seconds >= 0) {
-        return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
-    }
-    const dateMs = Date.parse(header);
-    if (Number.isFinite(dateMs)) {
-        return Math.max(0, Math.min(dateMs - Date.now(), MAX_RETRY_DELAY_MS));
-    }
-    return null;
+function statusRetryReporter(node, statusText) {
+    return function({ status, delayMs }) {
+        const waitSecs = Math.max(1, Math.ceil(delayMs / 1000));
+        node.status({fill: 'yellow', shape: 'ring', text: `${statusText} (HTTP ${status}, retry in ${waitSecs}s)`});
+    };
 }
 
 /**
- * Exponential backoff delay with mild jitter to avoid thundering herd.
- * @param {number} attempt - 1-indexed attempt number
- * @returns {number} delay in milliseconds
- */
-function backoffDelayMs(attempt) {
-    const jitter = 0.9 + Math.random() * 0.2;
-    return Math.min(BASE_RETRY_DELAY_MS * Math.pow(2, attempt - 1) * jitter, MAX_RETRY_DELAY_MS);
-}
-
-/**
- * Wrap a request function with retry-on-transient-failure (429 / 5xx).
- * 429 honours Retry-After; 5xx and 429-without-Retry-After use exponential backoff.
- * Non-retryable errors are rethrown immediately.
- * @param {object} node - The Node-RED node instance
- * @param {Function} requestFn - Function that performs one request attempt
- * @param {string} statusText - Base text for the node status during retry waits
- * @returns {Promise<object>} Response from the first successful attempt
- */
-async function executeWithRetry(node, requestFn, statusText) {
-    for (let attempt = 0; ; attempt++) {
-        try {
-            return await requestFn();
-        } catch (error) {
-            const status = error.response?.status;
-            if (!RETRYABLE_STATUSES.has(status) || attempt >= MAX_RETRIES) {
-                throw error;
-            }
-            const nextAttempt = attempt + 1;
-            const retryAfterMs = status === 429
-                ? parseRetryAfter(error.response.headers?.['retry-after'])
-                : null;
-            const delayMs = retryAfterMs ?? backoffDelayMs(nextAttempt);
-            const waitSecs = Math.max(1, Math.ceil(delayMs / 1000));
-            node.status({fill: 'yellow', shape: 'ring', text: `${statusText} (HTTP ${status}, retry in ${waitSecs}s)`});
-            node.debug(`HTTP ${status} - retrying in ${delayMs}ms (attempt ${nextAttempt}/${MAX_RETRIES})`);
-            await new Promise(resolve => setTimeout(resolve, delayMs));
-        }
-    }
-}
-
-/**
- * Execute an API request with automatic token refresh on 401 error
- * @param {object} node - The Node-RED node instance
- * @param {Function} requestFn - Function that executes the API request
- * @returns {Promise<object>} Response data
- */
-async function executeWithTokenRefresh(node, requestFn) {
-    try {
-        return await requestFn();
-    } catch (error) {
-        // Check if error is 401 Unauthorized (invalid token)
-        if (error.response && error.response.status === 401) {
-            node.debug('Received 401 error, attempting to refresh token and retry');
-            
-            try {
-                // Attempt to refresh the token
-                await node.config.refreshAccessToken();
-                
-                node.debug('Retrying request with refreshed token');
-                
-                // Retry the request with the new token
-                return await requestFn();
-            } catch (refreshError) {
-                // If refresh fails, throw the original error
-                node.debug(`Token refresh failed: ${refreshError.message}`);
-                throw error;
-            }
-        }
-        
-        throw error;
-    }
-}
-
-/**
- * Execute an API GET request with standard error handling
+ * Execute an API GET via the shared ViessmannClient with UI side effects
+ * (status icon + node.error on failure) layered on top.
  * @param {object} node - The Node-RED node instance
  * @param {object} msg - The incoming message
  * @param {string} url - The API endpoint URL
  * @param {string} statusText - Text to show during operation (default: 'fetching...')
  * @param {string} errorPrefix - Prefix for error messages (default: 'Failed to fetch data')
- * @returns {Promise<object>} Response data
  */
 async function executeApiGet(node, msg, url, statusText = 'fetching...', errorPrefix = 'Failed to fetch data') {
     try {
         node.status({fill: 'yellow', shape: 'ring', text: statusText});
-
         node.debug(`Executing GET ${url}`);
-
-        // Retry transient 429/5xx around the token-refresh-aware request.
-        const response = await executeWithRetry(node, () => executeWithTokenRefresh(node, async () => {
-            const token = await node.config.getValidToken();
-            return await axios.get(url, {
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Accept': 'application/json'
-                },
-                timeout: HTTP_TIMEOUT_MS
-            });
-        }), statusText);
-
+        const response = await node.config.client.get(url, {
+            onRetryWait: statusRetryReporter(node, statusText)
+        });
         node.status({fill: 'green', shape: 'dot', text: 'success'});
         return response;
     } catch (error) {
@@ -389,34 +285,15 @@ async function executeApiGet(node, msg, url, statusText = 'fetching...', errorPr
 }
 
 /**
- * Execute an API POST request with standard error handling
- * @param {object} node - The Node-RED node instance
- * @param {object} msg - The incoming message
- * @param {string} url - The API endpoint URL
- * @param {object} data - The data to post
- * @param {string} statusText - Text to show during operation (default: 'writing...')
- * @param {string} errorPrefix - Prefix for error messages (default: 'Failed to write data')
- * @returns {Promise<object>} Response data
+ * Execute an API POST via the shared ViessmannClient with UI side effects.
  */
 async function executeApiPost(node, msg, url, data, statusText = 'writing...', errorPrefix = 'Failed to write data') {
     try {
         node.status({fill: 'yellow', shape: 'ring', text: statusText});
-
         node.debug(`Executing POST ${url} with data: ${JSON.stringify(data)}`);
-
-        // Retry transient 429/5xx around the token-refresh-aware request.
-        const response = await executeWithRetry(node, () => executeWithTokenRefresh(node, async () => {
-            const token = await node.config.getValidToken();
-            return await axios.post(url, data, {
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json'
-                },
-                timeout: HTTP_TIMEOUT_MS
-            });
-        }), statusText);
-
+        const response = await node.config.client.post(url, data, {
+            onRetryWait: statusRetryReporter(node, statusText)
+        });
         node.status({fill: 'green', shape: 'dot', text: 'success'});
         return response;
     } catch (error) {

--- a/test/client_spec.js
+++ b/test/client_spec.js
@@ -1,0 +1,130 @@
+const { expect } = require('chai');
+const nock = require('nock');
+const { ViessmannClient } = require('../nodes/lib/client');
+
+const BASE_URL = 'https://example.test';
+
+function makeFakeConfig({ token = 'token-1', onRefresh } = {}) {
+    return {
+        _token: token,
+        getValidToken: async function() { return this._token; },
+        refreshAccessToken: async function() {
+            if (onRefresh) {
+                await onRefresh(this);
+            }
+        }
+    };
+}
+
+describe('ViessmannClient', function() {
+    afterEach(function() {
+        nock.cleanAll();
+    });
+
+    it('exposes get and post', function() {
+        const c = new ViessmannClient(makeFakeConfig());
+        expect(c.get).to.be.a('function');
+        expect(c.post).to.be.a('function');
+    });
+
+    it('attaches Bearer token and uses the configured baseURL', async function() {
+        nock(BASE_URL)
+            .get('/path')
+            .matchHeader('Authorization', 'Bearer my-token')
+            .reply(200, { ok: true });
+
+        const client = new ViessmannClient(makeFakeConfig({ token: 'my-token' }), { baseURL: BASE_URL });
+        const response = await client.get('/path');
+
+        expect(response.data).to.deep.equal({ ok: true });
+    });
+
+    it('refreshes token and retries on 401', async function() {
+        let refreshes = 0;
+        const config = makeFakeConfig({
+            token: 'expired',
+            onRefresh(self) { refreshes += 1; self._token = 'fresh'; }
+        });
+
+        nock(BASE_URL)
+            .get('/path').matchHeader('Authorization', 'Bearer expired').reply(401, { message: 'expired' })
+            .get('/path').matchHeader('Authorization', 'Bearer fresh').reply(200, { ok: true });
+
+        const client = new ViessmannClient(config, { baseURL: BASE_URL });
+        const response = await client.get('/path');
+
+        expect(refreshes).to.equal(1);
+        expect(response.data).to.deep.equal({ ok: true });
+    });
+
+    it('retries on 429 honoring Retry-After', async function() {
+        let onRetryCalls = 0;
+
+        nock(BASE_URL)
+            .get('/p').reply(429, '', { 'Retry-After': '0' })
+            .get('/p').reply(200, { ok: 1 });
+
+        const client = new ViessmannClient(makeFakeConfig(), { baseURL: BASE_URL });
+        const response = await client.get('/p', {
+            onRetryWait: () => { onRetryCalls += 1; }
+        });
+
+        expect(response.data).to.deep.equal({ ok: 1 });
+        expect(onRetryCalls).to.equal(1);
+    });
+
+    it('caps retries at the configured maxRetries', async function() {
+        nock(BASE_URL)
+            .get('/p').reply(429, '', { 'Retry-After': '0' })
+            .get('/p').reply(429, '', { 'Retry-After': '0' });
+
+        const client = new ViessmannClient(makeFakeConfig(), {
+            baseURL: BASE_URL,
+            maxRetries: 1
+        });
+
+        try {
+            await client.get('/p', { onRetryWait: () => {} });
+            throw new Error('expected throw');
+        } catch (err) {
+            expect(err.response.status).to.equal(429);
+        }
+    });
+
+    it('does not retry non-retryable statuses', async function() {
+        nock(BASE_URL)
+            .get('/p').reply(404);
+
+        const client = new ViessmannClient(makeFakeConfig(), { baseURL: BASE_URL });
+
+        try {
+            await client.get('/p');
+            throw new Error('expected throw');
+        } catch (err) {
+            expect(err.response.status).to.equal(404);
+        }
+    });
+
+    it('does not retry the same request twice on 401 if refresh succeeded but server still rejects', async function() {
+        let refreshes = 0;
+        const config = makeFakeConfig({
+            token: 'tok',
+            onRefresh(self) { refreshes += 1; self._token = 'tok2'; }
+        });
+
+        nock(BASE_URL)
+            .get('/p').reply(401)
+            .get('/p').reply(401);
+
+        const client = new ViessmannClient(config, { baseURL: BASE_URL });
+
+        try {
+            await client.get('/p');
+            throw new Error('expected throw');
+        } catch (err) {
+            expect(err.response.status).to.equal(401);
+            // We refresh exactly once; the second 401 propagates as the original error.
+            expect(refreshes).to.equal(1);
+        }
+    });
+});


### PR DESCRIPTION
Closes #58.

## Summary
- New `nodes/lib/client.js` exporting `ViessmannClient`. Owns the axios instance (baseURL, timeout, default headers), 401-driven token refresh, and 429/5xx retry policy.
- Config node now constructs one client on init and exposes it as `node.config.client`.
- `executeApiGet` / `executeApiPost` in `viessmann-helpers.js` delegate transport to the client; keep status icon + `node.error` on top.
- An `onRetryWait` callback lets the wrapper surface live retry countdowns in the node status without coupling the client to Node-RED.

## What did not change
- Node-RED node behavior / msg flow.
- The refresh-token POST stays in the config node — refresh-token rotation is intertwined with credential persistence, and lifting that into the client would require a credentials-provider abstraction that's out of scope here.
- Existing callers pass absolute URLs and continue to work (axios uses absolute URL even when an instance has `baseURL`).

## Internal multi-perspective review
- **Code quality** — single source of truth for transport; client is unit-testable without the Node-RED helper.
- **Architecture** — direct fix for #58. Future work (caching #63, rate-limit throttling, alternate base URLs, request-id headers) now has an obvious home.
- **Security** — same TLS / timeout / header behavior as before. No new attack surface.
- **Error handling** — behavior preserved: 401 → refresh → retry; 429 honors `Retry-After`; 5xx exponential backoff with jitter; non-retryable propagates.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 155 passing (was 148; +7 direct client unit tests).
- [x] Existing integration test "should refresh token and retry on 401 error" still passes — confirms the refactor preserves end-to-end refresh behavior.