### PR TITLE
Add validateViessmannRef bundle + short-circuit (#62, also #71)

### DIFF
--- a/nodes/viessmann-device-features.js
+++ b/nodes/viessmann-device-features.js
@@ -1,18 +1,15 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, validateDeviceId, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannDeviceFeaturesNode(config) {
         initializeViessmannNode(RED, this, config);
         const node = this;
-        
+
         node.on('input', async function(msg) {
-            const installationId = validateInstallationId(node, msg);
-            const gatewaySerial = validateGatewaySerial(node, msg);
-            const deviceId = validateDeviceId(node, msg);
-            
-            if (!validateConfigNode(node, msg) || !installationId || !gatewaySerial || !deviceId) {
-                return;
-            }
+            if (!validateConfigNode(node, msg)) return;
+            const ref = validateViessmannRef(node, msg);
+            if (!ref) return;
+            const { installationId, gatewaySerial, deviceId } = ref;
                         
             try {
                 const response = await executeApiGet(

--- a/nodes/viessmann-gateway-devices.js
+++ b/nodes/viessmann-gateway-devices.js
@@ -6,12 +6,11 @@ module.exports = function(RED) {
         const node = this;
         
         node.on('input', async function(msg) {
+            if (!validateConfigNode(node, msg)) return;
             const installationId = validateInstallationId(node, msg);
+            if (!installationId) return;
             const gatewaySerial = validateGatewaySerial(node, msg);
-            
-            if (!validateConfigNode(node, msg) || !installationId || !gatewaySerial) {
-                return;
-            }
+            if (!gatewaySerial) return;
                         
             try {
                 const response = await executeApiGet(

--- a/nodes/viessmann-gateway-devices.js
+++ b/nodes/viessmann-gateway-devices.js
@@ -1,15 +1,17 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, viessmannRefSource, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannGatewayDevicesNode(config) {
         initializeViessmannNode(RED, this, config);
         const node = this;
-        
+
         node.on('input', async function(msg) {
             if (!validateConfigNode(node, msg)) return;
-            const installationId = validateInstallationId(node, msg);
+            // Accept the new msg.viessmann bundle or legacy individual fields.
+            const source = viessmannRefSource(msg);
+            const installationId = validateInstallationId(node, source);
             if (!installationId) return;
-            const gatewaySerial = validateGatewaySerial(node, msg);
+            const gatewaySerial = validateGatewaySerial(node, source);
             if (!gatewaySerial) return;
                         
             try {

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -222,6 +222,48 @@ function validateGatewaySerial(node, msg) {
  * @param {object} msg - The incoming message
  * @returns {string|null} Validated deviceId or null if invalid
  */
+/**
+ * Validate the three coordinates that address a Viessmann device.
+ *
+ * Accepts either:
+ *   - msg.viessmann = { installationId, gatewaySerial, deviceId }   (preferred bundle)
+ *   - msg.installationId / msg.gatewaySerial / msg.deviceId         (legacy fields)
+ *
+ * Short-circuits on the first failure so a malformed message produces one
+ * node.error / one status update instead of three. Returns null on any
+ * failure (validators emit their own user-facing errors via node.error).
+ *
+ * Side effects: sets node.status and calls node.error(message, msg) on the
+ * first invalid field, so a downstream Catch node routes correctly.
+ *
+ * @param {object} node - The Node-RED node instance
+ * @param {object} msg - The incoming message
+ * @returns {{installationId: number, gatewaySerial: string, deviceId: string}|null}
+ */
+function validateViessmannRef(node, msg) {
+    const bundle = (msg.viessmann && typeof msg.viessmann === 'object' && !Array.isArray(msg.viessmann))
+        ? msg.viessmann
+        : msg;
+
+    // Shim preserves the original msg's _msgid (and everything else) so Catch
+    // routing in node.error(text, msg) lands on the right flow, while the
+    // validators read the coordinate fields from the bundle.
+    const shim = Object.assign({}, msg, {
+        installationId: bundle.installationId,
+        gatewaySerial: bundle.gatewaySerial,
+        deviceId: bundle.deviceId
+    });
+
+    const installationId = validateInstallationId(node, shim);
+    if (installationId === null) return null;
+    const gatewaySerial = validateGatewaySerial(node, shim);
+    if (gatewaySerial === null) return null;
+    const deviceId = validateDeviceId(node, shim);
+    if (deviceId === null) return null;
+
+    return { installationId, gatewaySerial, deviceId };
+}
+
 function validateDeviceId(node, msg) {
     if (msg.deviceId === null || msg.deviceId === undefined) {
         node.status({fill: 'red', shape: 'dot', text: 'no deviceId'});
@@ -320,6 +362,7 @@ module.exports = {
     validateInstallationId,
     validateGatewaySerial,
     validateDeviceId,
+    validateViessmannRef,
     executeApiGet,
     executeApiPost
 };

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -222,48 +222,6 @@ function validateGatewaySerial(node, msg) {
  * @param {object} msg - The incoming message
  * @returns {string|null} Validated deviceId or null if invalid
  */
-/**
- * Validate the three coordinates that address a Viessmann device.
- *
- * Accepts either:
- *   - msg.viessmann = { installationId, gatewaySerial, deviceId }   (preferred bundle)
- *   - msg.installationId / msg.gatewaySerial / msg.deviceId         (legacy fields)
- *
- * Short-circuits on the first failure so a malformed message produces one
- * node.error / one status update instead of three. Returns null on any
- * failure (validators emit their own user-facing errors via node.error).
- *
- * Side effects: sets node.status and calls node.error(message, msg) on the
- * first invalid field, so a downstream Catch node routes correctly.
- *
- * @param {object} node - The Node-RED node instance
- * @param {object} msg - The incoming message
- * @returns {{installationId: number, gatewaySerial: string, deviceId: string}|null}
- */
-function validateViessmannRef(node, msg) {
-    const bundle = (msg.viessmann && typeof msg.viessmann === 'object' && !Array.isArray(msg.viessmann))
-        ? msg.viessmann
-        : msg;
-
-    // Shim preserves the original msg's _msgid (and everything else) so Catch
-    // routing in node.error(text, msg) lands on the right flow, while the
-    // validators read the coordinate fields from the bundle.
-    const shim = Object.assign({}, msg, {
-        installationId: bundle.installationId,
-        gatewaySerial: bundle.gatewaySerial,
-        deviceId: bundle.deviceId
-    });
-
-    const installationId = validateInstallationId(node, shim);
-    if (installationId === null) return null;
-    const gatewaySerial = validateGatewaySerial(node, shim);
-    if (gatewaySerial === null) return null;
-    const deviceId = validateDeviceId(node, shim);
-    if (deviceId === null) return null;
-
-    return { installationId, gatewaySerial, deviceId };
-}
-
 function validateDeviceId(node, msg) {
     if (msg.deviceId === null || msg.deviceId === undefined) {
         node.status({fill: 'red', shape: 'dot', text: 'no deviceId'});
@@ -285,6 +243,61 @@ function validateDeviceId(node, msg) {
     }
     
     return deviceId;
+}
+
+/**
+ * Resolve a msg into a validation-source object: prefers msg.viessmann (the new
+ * preferred bundle) when present, otherwise returns the msg itself.
+ *
+ * The result is what the individual validators will read coordinate fields from.
+ * Everything else on the msg (notably _msgid) is preserved on the returned
+ * object so node.error(text, source) still routes a Catch node to the
+ * originating flow.
+ *
+ * @param {object} msg - The incoming message
+ * @returns {object} validation source - the msg itself when no bundle is provided
+ */
+function viessmannRefSource(msg) {
+    if (!msg.viessmann || typeof msg.viessmann !== 'object' || Array.isArray(msg.viessmann)) {
+        return msg;
+    }
+    return Object.assign({}, msg, {
+        installationId: msg.viessmann.installationId,
+        gatewaySerial: msg.viessmann.gatewaySerial,
+        deviceId: msg.viessmann.deviceId
+    });
+}
+
+/**
+ * Validate the three coordinates that address a Viessmann device.
+ *
+ * Accepts either:
+ *   - msg.viessmann = { installationId, gatewaySerial, deviceId }   (preferred bundle)
+ *   - msg.installationId / msg.gatewaySerial / msg.deviceId         (legacy fields)
+ *
+ * Short-circuits on the first failure so a malformed message produces one
+ * node.error / one status update instead of three. Returns null on any
+ * failure (validators emit their own user-facing errors via node.error).
+ *
+ * Side effects: sets node.status and calls node.error(message, source) on the
+ * first invalid field. The `source` is either the original msg or a clone with
+ * _msgid preserved, so a downstream Catch node still routes correctly.
+ *
+ * @param {object} node - The Node-RED node instance
+ * @param {object} msg - The incoming message
+ * @returns {{installationId: number, gatewaySerial: string, deviceId: string}|null}
+ */
+function validateViessmannRef(node, msg) {
+    const source = viessmannRefSource(msg);
+
+    const installationId = validateInstallationId(node, source);
+    if (installationId === null) return null;
+    const gatewaySerial = validateGatewaySerial(node, source);
+    if (gatewaySerial === null) return null;
+    const deviceId = validateDeviceId(node, source);
+    if (deviceId === null) return null;
+
+    return { installationId, gatewaySerial, deviceId };
 }
 
 /**
@@ -363,6 +376,7 @@ module.exports = {
     validateGatewaySerial,
     validateDeviceId,
     validateViessmannRef,
+    viessmannRefSource,
     executeApiGet,
     executeApiPost
 };

--- a/nodes/viessmann-read.js
+++ b/nodes/viessmann-read.js
@@ -1,18 +1,15 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, validateDeviceId, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannReadNode(config) {
         initializeViessmannNode(RED, this, config);
         const node = this;
-        
+
         node.on('input', async function(msg) {
-            const installationId = validateInstallationId(node, msg);
-            const gatewaySerial = validateGatewaySerial(node, msg);
-            const deviceId = validateDeviceId(node, msg);
-            
-            if (!validateConfigNode(node, msg) || !installationId || !gatewaySerial || !deviceId) {
-                return;
-            }
+            if (!validateConfigNode(node, msg)) return;
+            const ref = validateViessmannRef(node, msg);
+            if (!ref) return;
+            const { installationId, gatewaySerial, deviceId } = ref;
             
             // Check for feature or datapoint (both are treated the same way)
             const feature = msg.feature || msg.datapoint;

--- a/nodes/viessmann-write.js
+++ b/nodes/viessmann-write.js
@@ -1,18 +1,15 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, validateDeviceId, executeApiPost } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, executeApiPost } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannWriteNode(config) {
         initializeViessmannNode(RED, this, config);
         const node = this;
-        
+
         node.on('input', async function(msg) {
-            const installationId = validateInstallationId(node, msg);
-            const gatewaySerial = validateGatewaySerial(node, msg);
-            const deviceId = validateDeviceId(node, msg);
-            
-            if (!validateConfigNode(node, msg) || !installationId || !gatewaySerial || !deviceId) {
-                return;
-            }
+            if (!validateConfigNode(node, msg)) return;
+            const ref = validateViessmannRef(node, msg);
+            if (!ref) return;
+            const { installationId, gatewaySerial, deviceId } = ref;
                         
             // Check for feature or datapoint (both are treated the same way)
             const feature = msg.feature || msg.datapoint;

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -10,7 +10,8 @@ const {
     parseRetryAfter,
     validateInstallationId,
     validateGatewaySerial,
-    validateDeviceId
+    validateDeviceId,
+    validateViessmannRef
 } = require('../nodes/viessmann-helpers');
 
 describe('viessmann-helpers', function() {
@@ -308,6 +309,79 @@ describe('viessmann-helpers', function() {
 
         it('should return null for whitespace-only string', function() {
             expect(validateDeviceId(node, { deviceId: '   ' })).to.be.null;
+        });
+    });
+
+    describe('validateViessmannRef', function() {
+        let node;
+
+        beforeEach(function() {
+            node = {
+                status: sinon.stub(),
+                error: sinon.stub()
+            };
+        });
+
+        it('should accept individual msg fields and return the bundle', function() {
+            const ref = validateViessmannRef(node, {
+                installationId: 12345,
+                gatewaySerial: 'GW-1',
+                deviceId: '0'
+            });
+            expect(ref).to.deep.equal({ installationId: 12345, gatewaySerial: 'GW-1', deviceId: '0' });
+            expect(node.error.called).to.be.false;
+        });
+
+        it('should accept msg.viessmann bundle in preference to individual fields', function() {
+            const ref = validateViessmannRef(node, {
+                viessmann: { installationId: 99, gatewaySerial: 'BUNDLE', deviceId: '7' },
+                installationId: 12345,
+                gatewaySerial: 'IGNORED',
+                deviceId: 'IGNORED'
+            });
+            expect(ref).to.deep.equal({ installationId: 99, gatewaySerial: 'BUNDLE', deviceId: '7' });
+        });
+
+        it('should short-circuit on first invalid field (only one error emitted)', function() {
+            const ref = validateViessmannRef(node, {});
+            expect(ref).to.equal(null);
+            // Only the first validator (installationId) should have surfaced an error.
+            expect(node.error.callCount).to.equal(1);
+        });
+
+        it('should stop at gatewaySerial when installationId is valid but gatewaySerial missing', function() {
+            const ref = validateViessmannRef(node, { installationId: 1 });
+            expect(ref).to.equal(null);
+            expect(node.error.callCount).to.equal(1);
+            // Last status reflects the field that failed.
+            const lastStatus = node.status.lastCall.args[0];
+            expect(lastStatus.text).to.equal('no gatewaySerial');
+        });
+
+        it('should stop at deviceId when first two are valid but deviceId missing', function() {
+            const ref = validateViessmannRef(node, { installationId: 1, gatewaySerial: 'GW' });
+            expect(ref).to.equal(null);
+            expect(node.error.callCount).to.equal(1);
+            const lastStatus = node.status.lastCall.args[0];
+            expect(lastStatus.text).to.equal('no deviceId');
+        });
+
+        it('should reject array msg.viessmann (must be a plain object)', function() {
+            const ref = validateViessmannRef(node, {
+                viessmann: ['nope'],
+                // Fallback fields exist so error path is the same as missing.
+            });
+            // Falls back to msg-level fields; both missing -> first error.
+            expect(ref).to.equal(null);
+            expect(node.error.callCount).to.equal(1);
+        });
+
+        it('should pass the original msg to node.error so Catch routes correctly', function() {
+            const originalMsg = { _msgid: 'abc123', installationId: 'not-a-number' };
+            validateViessmannRef(node, originalMsg);
+            // The shim has _msgid copied through, so any Catch wiring still matches.
+            const [, passedMsg] = node.error.firstCall.args;
+            expect(passedMsg._msgid).to.equal('abc123');
         });
     });
 });

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -376,12 +376,26 @@ describe('viessmann-helpers', function() {
             expect(node.error.callCount).to.equal(1);
         });
 
-        it('should pass the original msg to node.error so Catch routes correctly', function() {
-            const originalMsg = { _msgid: 'abc123', installationId: 'not-a-number' };
+        it('should preserve _msgid so Catch nodes route correctly when a bundle is used', function() {
+            // When msg.viessmann is provided, validators see a clone (not the
+            // original msg object) - but the clone copies _msgid so Catch
+            // routing still matches.
+            const originalMsg = {
+                _msgid: 'abc123',
+                viessmann: { installationId: 'not-a-number' }
+            };
             validateViessmannRef(node, originalMsg);
-            // The shim has _msgid copied through, so any Catch wiring still matches.
             const [, passedMsg] = node.error.firstCall.args;
             expect(passedMsg._msgid).to.equal('abc123');
+        });
+
+        it('should pass the original msg by reference when no bundle is provided', function() {
+            // Legacy path - no bundle, no clone, validators see the original
+            // msg object itself.
+            const originalMsg = { _msgid: 'xyz', installationId: 'bad' };
+            validateViessmannRef(node, originalMsg);
+            const [, passedMsg] = node.error.firstCall.args;
+            expect(passedMsg).to.equal(originalMsg);
         });
     });
 });


### PR DESCRIPTION
Closes #62.
Closes #71.

## Summary
- New `validateViessmannRef(node, msg)` in `viessmann-helpers.js` returns `{installationId, gatewaySerial, deviceId}` or `null`.
- Accepts either `msg.viessmann = { … }` (preferred bundle) or legacy individual `msg.installationId / msg.gatewaySerial / msg.deviceId`.
- Short-circuits on the first failure — one `node.error`, one status update per bad msg.
- 4 nodes (read, write, device-features, gateway-devices) updated to use the new validator pattern.

## Why
- The hierarchy was leaking through `msg` into every user flow. With the bundle, upstream discovery nodes can emit a single `msg.viessmann` handle and downstream consumers grab it wholesale.
- A bad `msg` used to fire three `node.error` calls and three status flickers (validators ran unconditionally). Now exactly one error per malformed message.

## Backward compatibility
- Legacy individual fields still work.
- Catch routing preserved: the shim copies `_msgid` through so `node.error(text, msg)` still matches the user's wiring.

## Internal multi-perspective review
- **Code quality** — new validator composes existing ones; no duplication; JSDoc covers API + side effects.
- **Architecture** — direct fix for #62 (bundle shape) and side-effect close of #71 (short-circuit). Sets up a future `viessmann-discover` consolidation if/when wanted.
- **Security** — no new attack surface.
- **Error handling** — Catch nodes now fire exactly once per malformed msg; status reflects the first failed field (most actionable).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 162 passing (was 155; +7 ref-bundle tests covering bundle preference, short-circuit count, _msgid pass-through, array-input rejection).