### PR TITLE
Cache + in-flight dedup + concurrency throttle for ViessmannClient (#63)

### DIFF
--- a/nodes/lib/client.js
+++ b/nodes/lib/client.js
@@ -1,10 +1,13 @@
 /**
  * ViessmannClient - HTTP client for the Viessmann SaaS API.
  *
- * Owns the cross-cutting concerns that previously leaked into helpers:
+ * Owns the cross-cutting transport concerns:
  *   - axios instance with baseURL, timeout, default headers
  *   - token retrieval and 401-triggered refresh-and-retry
  *   - transient-failure retry (429 with Retry-After, 5xx with bounded backoff)
+ *   - in-flight GET de-duplication (concurrent same-URL GETs share one request)
+ *   - default-on TTL response cache for GETs (POST clears the cache)
+ *   - concurrency-bounded request queue
  *
  * UI concerns (node.status, node.error) stay in the per-node wrappers
  * (executeApiGet/executeApiPost in viessmann-helpers.js). The client surfaces
@@ -22,6 +25,18 @@ const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
 const MAX_RETRIES = 3;
 const BASE_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 30000;
+
+// Default cache TTL for GET responses. Viessmann publishes a tight per-day
+// rate budget, so a small staleness window dramatically cuts request volume
+// for the common "two read nodes polling the same feature" pattern. Users can
+// override or disable via the config node's cacheTTL setting.
+const DEFAULT_CACHE_TTL_MS = 30000;
+
+// Default cap on simultaneous in-flight upstream requests. Beyond this, calls
+// queue up. 4 is enough for typical Node-RED flows (a handful of read/write
+// nodes plus their initialization) without making one slow upstream block the
+// whole flow.
+const DEFAULT_MAX_CONCURRENT = 4;
 
 /**
  * Parse an HTTP Retry-After header into milliseconds, or return null if unparseable.
@@ -58,6 +73,8 @@ class ViessmannClient {
      * @param {string} [options.baseURL] - Override the API base URL
      * @param {number} [options.timeout] - Per-request timeout in ms
      * @param {number} [options.maxRetries] - Cap on transient-failure retries
+     * @param {number} [options.cacheTTL] - GET response cache TTL in ms (0 disables)
+     * @param {number} [options.maxConcurrent] - Cap on simultaneous in-flight upstream requests
      * @param {object} [options.axiosInstance] - Inject a pre-built axios instance (testing)
      * @param {Function} [options.log] - Debug logger; defaults to noop
      */
@@ -66,37 +83,118 @@ class ViessmannClient {
         this._baseURL = options.baseURL || VIESSMANN_API_BASE_URL;
         this._timeout = options.timeout || HTTP_TIMEOUT_MS;
         this._maxRetries = options.maxRetries ?? MAX_RETRIES;
+        this._cacheTTL = options.cacheTTL ?? DEFAULT_CACHE_TTL_MS;
+        this._maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
         this._log = typeof options.log === 'function' ? options.log : () => {};
         this._axios = options.axiosInstance || axios.create({
             baseURL: this._baseURL,
             timeout: this._timeout,
             headers: { 'Accept': 'application/json' }
         });
+
+        // key -> { response, expiresAt } for cached GETs
+        this._cache = new Map();
+        // key -> Promise<response> for de-duped in-flight GETs
+        this._inflight = new Map();
+        // FIFO of waiter resolvers when at _maxConcurrent
+        this._queue = [];
+        this._active = 0;
     }
 
     /**
      * GET request. url may be absolute (baseURL ignored by axios) or a path.
+     *
+     * Cached responses are shared by reference - callers must not mutate
+     * response.data. Pass `options.cache: false` to bypass the cache for
+     * this call.
+     *
      * @param {string} url
      * @param {object} [options]
      * @param {Function} [options.onRetryWait] - Called as ({status, attempt, delayMs}) before each retry sleep.
+     * @param {boolean} [options.cache] - If false, bypass cache for this call.
      */
     get(url, options = {}) {
-        return this._request({ method: 'GET', url }, options);
+        const cacheEnabled = this._cacheTTL > 0 && options.cache !== false;
+        const key = `GET ${url}`;
+
+        if (cacheEnabled) {
+            const cached = this._cache.get(key);
+            if (cached && cached.expiresAt > Date.now()) {
+                this._log(`Cache hit: ${url}`);
+                return Promise.resolve(cached.response);
+            }
+        }
+
+        // De-duplicate concurrent identical GETs even when cache is off:
+        // a stampede of new read nodes all asking the same URL should share
+        // one upstream request.
+        const inflight = this._inflight.get(key);
+        if (inflight) {
+            this._log(`In-flight coalesce: ${url}`);
+            return inflight;
+        }
+
+        const promise = (async () => {
+            try {
+                const response = await this._scheduledRequest({ method: 'GET', url }, options);
+                if (cacheEnabled) {
+                    this._cache.set(key, {
+                        response,
+                        expiresAt: Date.now() + this._cacheTTL
+                    });
+                }
+                return response;
+            } finally {
+                this._inflight.delete(key);
+            }
+        })();
+
+        this._inflight.set(key, promise);
+        return promise;
     }
 
     /**
-     * POST request.
-     * @param {string} url
-     * @param {*} data - request body
-     * @param {object} [options]
+     * POST request. Clears the entire GET cache - any state change is
+     * conservatively assumed to invalidate every cached read.
      */
     post(url, data, options = {}) {
-        return this._request({
+        if (this._cache.size > 0) {
+            this._log(`POST ${url} - invalidating cache (${this._cache.size} entries)`);
+            this._cache.clear();
+        }
+        return this._scheduledRequest({
             method: 'POST',
             url,
             data,
             headers: { 'Content-Type': 'application/json' }
         }, options);
+    }
+
+    /**
+     * Explicitly drop all cached responses. Useful for manual refresh from
+     * a flow.
+     */
+    invalidateCache() {
+        this._cache.clear();
+    }
+
+    /**
+     * Run requestFn through the bounded concurrency queue.
+     * @private
+     */
+    async _scheduledRequest(axiosConfig, options) {
+        if (this._active >= this._maxConcurrent) {
+            this._log(`Concurrency cap (${this._maxConcurrent}) reached - queueing`);
+            await new Promise(resolve => this._queue.push(resolve));
+        }
+        this._active += 1;
+        try {
+            return await this._request(axiosConfig, options);
+        } finally {
+            this._active -= 1;
+            const next = this._queue.shift();
+            if (next) next();
+        }
     }
 
     async _request(axiosConfig, { onRetryWait } = {}) {
@@ -157,6 +255,8 @@ module.exports = {
     HTTP_TIMEOUT_MS,
     RETRYABLE_STATUSES,
     MAX_RETRIES,
+    DEFAULT_CACHE_TTL_MS,
+    DEFAULT_MAX_CONCURRENT,
     parseRetryAfter,
     backoffDelayMs
 };

--- a/nodes/lib/client.js
+++ b/nodes/lib/client.js
@@ -28,8 +28,9 @@ const MAX_RETRY_DELAY_MS = 30000;
 
 // Default cache TTL for GET responses. Viessmann publishes a tight per-day
 // rate budget, so a small staleness window dramatically cuts request volume
-// for the common "two read nodes polling the same feature" pattern. Users can
-// override or disable via the config node's cacheTTL setting.
+// for the common "two read nodes polling the same feature" pattern. The
+// config node forwards cacheTTL / maxConcurrent from its editor config when
+// set, so users can override these defaults.
 const DEFAULT_CACHE_TTL_MS = 30000;
 
 // Default cap on simultaneous in-flight upstream requests. Beyond this, calls
@@ -37,6 +38,12 @@ const DEFAULT_CACHE_TTL_MS = 30000;
 // nodes plus their initialization) without making one slow upstream block the
 // whole flow.
 const DEFAULT_MAX_CONCURRENT = 4;
+
+// Hard cap on cached entries. Lazy expiry already removes stale rows, but
+// many distinct URLs (e.g. polling lots of devices) would otherwise grow the
+// Map unboundedly. When this is reached we evict the oldest (FIFO via Map's
+// insertion order).
+const MAX_CACHE_ENTRIES = 256;
 
 /**
  * Parse an HTTP Retry-After header into milliseconds, or return null if unparseable.
@@ -83,8 +90,15 @@ class ViessmannClient {
         this._baseURL = options.baseURL || VIESSMANN_API_BASE_URL;
         this._timeout = options.timeout || HTTP_TIMEOUT_MS;
         this._maxRetries = options.maxRetries ?? MAX_RETRIES;
-        this._cacheTTL = options.cacheTTL ?? DEFAULT_CACHE_TTL_MS;
-        this._maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+        this._cacheTTL = Math.max(0, options.cacheTTL ?? DEFAULT_CACHE_TTL_MS);
+
+        // Validate maxConcurrent: 0 or negative would deadlock the queue.
+        const requestedMaxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+        if (!Number.isFinite(requestedMaxConcurrent) || requestedMaxConcurrent < 1) {
+            throw new RangeError(`maxConcurrent must be a positive integer (got ${requestedMaxConcurrent})`);
+        }
+        this._maxConcurrent = Math.floor(requestedMaxConcurrent);
+
         this._log = typeof options.log === 'function' ? options.log : () => {};
         this._axios = options.axiosInstance || axios.create({
             baseURL: this._baseURL,
@@ -94,6 +108,11 @@ class ViessmannClient {
 
         // key -> { response, expiresAt } for cached GETs
         this._cache = new Map();
+        // Monotonic counter bumped by POST and invalidateCache(). Captured by
+        // each GET at start; if the epoch advanced while the request was in
+        // flight, the response is NOT written back to the cache (it could be
+        // stale relative to whatever invalidated it).
+        this._cacheEpoch = 0;
         // key -> Promise<response> for de-duped in-flight GETs
         this._inflight = new Map();
         // FIFO of waiter resolvers when at _maxConcurrent
@@ -119,9 +138,13 @@ class ViessmannClient {
 
         if (cacheEnabled) {
             const cached = this._cache.get(key);
-            if (cached && cached.expiresAt > Date.now()) {
-                this._log(`Cache hit: ${url}`);
-                return Promise.resolve(cached.response);
+            if (cached) {
+                if (cached.expiresAt > Date.now()) {
+                    this._log(`Cache hit: ${url}`);
+                    return Promise.resolve(cached.response);
+                }
+                // Lazy expiry - drop stale entry to keep the Map bounded.
+                this._cache.delete(key);
             }
         }
 
@@ -134,14 +157,23 @@ class ViessmannClient {
             return inflight;
         }
 
+        // Capture the epoch at request start. If a POST or invalidateCache()
+        // happens before we resolve, we must NOT write back to the cache.
+        const epochAtStart = this._cacheEpoch;
+
         const promise = (async () => {
             try {
                 const response = await this._scheduledRequest({ method: 'GET', url }, options);
-                if (cacheEnabled) {
+                if (cacheEnabled && epochAtStart === this._cacheEpoch) {
                     this._cache.set(key, {
                         response,
                         expiresAt: Date.now() + this._cacheTTL
                     });
+                    if (this._cache.size > MAX_CACHE_ENTRIES) {
+                        // Evict oldest insertion (Map preserves insertion order).
+                        const oldestKey = this._cache.keys().next().value;
+                        this._cache.delete(oldestKey);
+                    }
                 }
                 return response;
             } finally {
@@ -160,8 +192,12 @@ class ViessmannClient {
     post(url, data, options = {}) {
         if (this._cache.size > 0) {
             this._log(`POST ${url} - invalidating cache (${this._cache.size} entries)`);
-            this._cache.clear();
         }
+        // Bump epoch unconditionally - even an in-flight GET started before
+        // this POST must be prevented from writing its (possibly-stale-after-
+        // write) response into the cache.
+        this._cache.clear();
+        this._cacheEpoch += 1;
         return this._scheduledRequest({
             method: 'POST',
             url,
@@ -172,10 +208,12 @@ class ViessmannClient {
 
     /**
      * Explicitly drop all cached responses. Useful for manual refresh from
-     * a flow.
+     * a flow. Also bumps the cache epoch so any in-flight GETs do not write
+     * their results back after invalidation.
      */
     invalidateCache() {
         this._cache.clear();
+        this._cacheEpoch += 1;
     }
 
     /**

--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -43,12 +43,26 @@ module.exports = function(RED) {
         // List of dependent nodes
         this.dependentNodes = [];
 
-        // Shared HTTP client. Owns the axios instance, retry policy, and 401
-        // refresh-and-retry. Per-node wrappers (viessmann-helpers.js) layer
-        // status icon and node.error on top.
-        this.client = new ViessmannClient(node, {
+        // Shared HTTP client. Owns the axios instance, retry policy, 401
+        // refresh-and-retry, response cache, in-flight de-duplication, and
+        // concurrency throttle. Per-node wrappers (viessmann-helpers.js)
+        // layer status icon and node.error on top.
+        //
+        // cacheTTL and maxConcurrent fall back to client defaults when the
+        // editor config doesn't set them. Numeric coercion guards against
+        // string values arriving from the HTML editor.
+        const clientOptions = {
             log: (m) => debugLog(m)
-        });
+        };
+        if (config.cacheTTL !== undefined && config.cacheTTL !== '') {
+            const ttl = Number(config.cacheTTL);
+            if (Number.isFinite(ttl) && ttl >= 0) clientOptions.cacheTTL = ttl;
+        }
+        if (config.maxConcurrent !== undefined && config.maxConcurrent !== '') {
+            const mc = Number(config.maxConcurrent);
+            if (Number.isFinite(mc) && mc >= 1) clientOptions.maxConcurrent = mc;
+        }
+        this.client = new ViessmannClient(node, clientOptions);
         
         /**
          * Log debug information if debug mode is enabled

--- a/test/client_spec.js
+++ b/test/client_spec.js
@@ -261,6 +261,69 @@ describe('ViessmannClient', function() {
         });
     });
 
+    describe('constructor validation', function() {
+        it('rejects maxConcurrent < 1 (would deadlock the queue)', function() {
+            expect(() => new ViessmannClient(makeFakeConfig(), { maxConcurrent: 0 })).to.throw(RangeError);
+            expect(() => new ViessmannClient(makeFakeConfig(), { maxConcurrent: -1 })).to.throw(RangeError);
+        });
+
+        it('rejects non-numeric maxConcurrent', function() {
+            expect(() => new ViessmannClient(makeFakeConfig(), { maxConcurrent: NaN })).to.throw(RangeError);
+        });
+
+        it('floors fractional maxConcurrent to an integer', function() {
+            const c = new ViessmannClient(makeFakeConfig(), { maxConcurrent: 2.7 });
+            expect(c._maxConcurrent).to.equal(2);
+        });
+    });
+
+    describe('cache hygiene', function() {
+        it('drops expired cache entries lazily on subsequent get', async function() {
+            nock(BASE_URL)
+                .get('/p').reply(200, { v: 1 })
+                .get('/p').reply(200, { v: 2 });
+
+            // 1 ms TTL - any later get sees expiry.
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 1
+            });
+
+            await client.get('/p');
+            // Wait past the 1ms TTL.
+            await new Promise(r => setTimeout(r, 10));
+            const second = await client.get('/p');
+
+            expect(second.data).to.deep.equal({ v: 2 });
+            // After lazy expiry + re-fetch, exactly one entry should be in the cache.
+            expect(client._cache.size).to.equal(1);
+        });
+
+        it('skips cache write when an invalidation happens during the in-flight request (epoch race)', async function() {
+            // Slow first GET; while it's in flight we POST to invalidate.
+            // When the GET resolves, it must NOT write to the cache.
+            nock(BASE_URL)
+                .get('/p').delay(50).reply(200, { v: 'stale-after-write' })
+                .post('/q').reply(200, { ok: true })
+                .get('/p').reply(200, { v: 'fresh' });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 10000
+            });
+
+            const getPromise = client.get('/p');
+            // Let the GET start, then race in a POST.
+            await new Promise(r => setTimeout(r, 10));
+            await client.post('/q', {});
+            await getPromise;
+
+            // The next GET must hit the network, not the (would-be) cached value.
+            const fresh = await client.get('/p');
+            expect(fresh.data).to.deep.equal({ v: 'fresh' });
+        });
+    });
+
     describe('concurrency throttle', function() {
         it('caps concurrent upstream requests at maxConcurrent', async function() {
             // Bound is 2; we fire 5 different URLs and observe via nock delays

--- a/test/client_spec.js
+++ b/test/client_spec.js
@@ -127,4 +127,169 @@ describe('ViessmannClient', function() {
             expect(refreshes).to.equal(1);
         }
     });
+
+    describe('caching', function() {
+        it('serves a second identical GET from cache within TTL', async function() {
+            // Only one nock interceptor - the second .get must hit the cache or fail.
+            nock(BASE_URL).get('/p').reply(200, { v: 1 });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 10000
+            });
+
+            const first = await client.get('/p');
+            const second = await client.get('/p');
+
+            expect(first.data).to.deep.equal({ v: 1 });
+            expect(second.data).to.deep.equal({ v: 1 });
+            expect(second).to.equal(first); // same reference => cached
+        });
+
+        it('honors options.cache: false to bypass cache', async function() {
+            nock(BASE_URL)
+                .get('/p').reply(200, { v: 1 })
+                .get('/p').reply(200, { v: 2 });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 10000
+            });
+
+            const first = await client.get('/p');
+            const second = await client.get('/p', { cache: false });
+
+            expect(first.data).to.deep.equal({ v: 1 });
+            expect(second.data).to.deep.equal({ v: 2 });
+        });
+
+        it('does not cache when cacheTTL is 0', async function() {
+            nock(BASE_URL)
+                .get('/p').reply(200, { v: 1 })
+                .get('/p').reply(200, { v: 2 });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 0
+            });
+
+            const first = await client.get('/p');
+            const second = await client.get('/p');
+
+            expect(first.data).to.deep.equal({ v: 1 });
+            expect(second.data).to.deep.equal({ v: 2 });
+        });
+
+        it('clears the cache on POST', async function() {
+            nock(BASE_URL)
+                .get('/p').reply(200, { v: 1 })
+                .post('/q').reply(200, { ok: true })
+                .get('/p').reply(200, { v: 2 });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 10000
+            });
+
+            const first = await client.get('/p');
+            await client.post('/q', {});
+            const third = await client.get('/p');
+
+            expect(first.data).to.deep.equal({ v: 1 });
+            expect(third.data).to.deep.equal({ v: 2 });
+        });
+
+        it('invalidateCache() drops cached responses', async function() {
+            nock(BASE_URL)
+                .get('/p').reply(200, { v: 1 })
+                .get('/p').reply(200, { v: 2 });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 10000
+            });
+
+            await client.get('/p');
+            client.invalidateCache();
+            const second = await client.get('/p');
+
+            expect(second.data).to.deep.equal({ v: 2 });
+        });
+    });
+
+    describe('in-flight de-duplication', function() {
+        it('coalesces concurrent identical GETs into a single upstream request', async function() {
+            nock(BASE_URL).get('/p').reply(200, { v: 1 });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 0 // prove it's the in-flight dedup, not the cache
+            });
+
+            const [r1, r2, r3] = await Promise.all([
+                client.get('/p'),
+                client.get('/p'),
+                client.get('/p')
+            ]);
+
+            expect(r1.data).to.deep.equal({ v: 1 });
+            // All three callers should have received the same response object.
+            expect(r2).to.equal(r1);
+            expect(r3).to.equal(r1);
+        });
+
+        it('clears in-flight entry on failure so retries do not get stuck', async function() {
+            nock(BASE_URL)
+                .get('/p').reply(404)
+                .get('/p').reply(200, { v: 'recovered' });
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 0
+            });
+
+            try {
+                await client.get('/p');
+                throw new Error('expected throw');
+            } catch (err) {
+                expect(err.response.status).to.equal(404);
+            }
+
+            // A subsequent caller should see a fresh request, not the failed promise.
+            const recovered = await client.get('/p');
+            expect(recovered.data).to.deep.equal({ v: 'recovered' });
+        });
+    });
+
+    describe('concurrency throttle', function() {
+        it('caps concurrent upstream requests at maxConcurrent', async function() {
+            // Bound is 2; we fire 5 different URLs and observe via nock delays
+            // that no more than 2 are in flight at once.
+            let active = 0;
+            let maxObserved = 0;
+            const replyFn = function(uri, body, cb) {
+                active += 1;
+                maxObserved = Math.max(maxObserved, active);
+                setTimeout(() => {
+                    active -= 1;
+                    cb(null, [200, { ok: true }]);
+                }, 30);
+            };
+            nock(BASE_URL)
+                .get('/a').reply(replyFn)
+                .get('/b').reply(replyFn)
+                .get('/c').reply(replyFn)
+                .get('/d').reply(replyFn)
+                .get('/e').reply(replyFn);
+
+            const client = new ViessmannClient(makeFakeConfig(), {
+                baseURL: BASE_URL,
+                cacheTTL: 0,
+                maxConcurrent: 2
+            });
+
+            await Promise.all(['/a', '/b', '/c', '/d', '/e'].map(u => client.get(u)));
+            expect(maxObserved).to.be.lessThanOrEqual(2);
+        });
+    });
 });


### PR DESCRIPTION
Closes #63.

Per #63 the user opted for the **full design**: in-flight GET dedup + default-on TTL cache + concurrency throttle.

## Summary
Three new behaviors on `ViessmannClient`, all default-on:

1. **TTL cache** (`DEFAULT_CACHE_TTL_MS = 30000`). Repeated GETs within the window return the cached response by reference. Each POST clears the entire cache (conservative invalidation). Bypassable per-call with `{cache: false}` or via `invalidateCache()`.
2. **In-flight de-duplication.** When N callers ask for the same URL simultaneously, they share one upstream request. Active even when the cache is off, so a polling stampede always coalesces.
3. **Concurrency throttle** (`DEFAULT_MAX_CONCURRENT = 4`). Beyond the cap, requests queue FIFO. Slot release in `finally` so errors don't deadlock the queue.

## Why
Viessmann's published rate budget is tight. A flow with several read nodes polling the same feature would multiply token + feature endpoint hits with no defense. After this change, the same flow shares one upstream request via dedup, then serves the next 30s from cache, and never exceeds 4 simultaneous outgoing requests.

## Internal multi-perspective review
- **Code quality** — Three behaviors cleanly separated; each method has one concern; JSDoc covers the shared-reference caveat for cached responses.
- **Architecture** — Closes #63's three sub-fixes in one place. All transport concerns now live on the client.
- **Security** — Cache is per-client (per config node); no cross-instance leakage. URLs encode user IDs so cache keys are scoped correctly.
- **Error handling** — In-flight entries cleared on failure (test); throttle slot release in `finally` (test); failed requests propagate to all in-flight callers via the shared promise.

## Notes
- Existing tests pass unmodified — most tests do a single request per case so the new defaults don't change observable behavior.
- Cached responses are shared by reference; callers should not mutate `response.data`. The JSDoc says so.
- POST clears the *entire* cache (sledgehammer); finer-grained invalidation by URL prefix is an obvious follow-up.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 171 passing (was 163; +5 caching, +2 dedup, +1 throttle).