### PR TITLE
Align SPEC.md and README.md with implemented auth flow (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Node-RED module for integrating Viessmann heating devices via the official Vie
 
 ## Features
 
-- **OAuth2 Authentication**: Secure authentication with Viessmann API using client credentials or device flow
+- **OAuth2 Authentication**: Authorization Code with PKCE for token bootstrap (via the bundled CLI), refresh-token grant at runtime; tokens stored securely via Node-RED credentials
 - **Installation Discovery**: List all accessible Viessmann installations for your account
 - **Gateway Discovery**: List all gateways for a specific installation
 - **Device Discovery**: List all devices attached to a specific gateway

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@
 
 ### a) Configuration Node: `viessmann-config`
 - Stores the public client ID and the pre-obtained access/refresh tokens securely via Node-RED's credential system.
-- Owns the runtime token lifecycle: validates the stored access token, refreshes it via the refresh token, and surfaces auth state to dependent nodes.
+- Owns the runtime token lifecycle: uses the stored access token until it's near expiry, then refreshes via the refresh token. Expired-but-not-yet-refreshed tokens are corrected reactively when the API returns 401 (the failing request retries once with a fresh token). Auth state is surfaced to dependent nodes.
 - Provides config for all Viessmann nodes.
 - **Does not perform interactive authentication itself.** Token bootstrap is an out-of-band step handled by `scripts/get-viessmann-tokens.js` (see §2.0).
 
@@ -78,8 +78,7 @@ Refer to the [Viessmann API Authentication Documentation](https://api.viessmann-
 
 ## 3. Key Implementation Decisions
 
-- **Authentication:** Authorization Code with PKCE for bootstrap (via `scripts/get-viessmann-tokens.js`); refresh-token grant at runtime (in `viessmann-config`). Default scopes: `IoT offline_access`. Concurrent refresh attempts are de-duplicated via an in-flight promise so the IdP's refresh-token rotation cannot race-invalidate the stored token.
-  - **Scopes are configurable**: Users can modify scopes if needed for their specific use case
+- **Authentication:** Authorization Code with PKCE for bootstrap (via `scripts/get-viessmann-tokens.js`); refresh-token grant at runtime (in `viessmann-config`). Scopes are fixed at `IoT offline_access` in the bootstrap script - changing them today requires editing the script. Concurrent refresh attempts are de-duplicated via an in-flight promise so the IdP's refresh-token rotation cannot race-invalidate the stored token.
   - **External setup required**: Users must obtain a Client ID from the Viessmann Developer Portal and run the bootstrap CLI before the Node-RED config node can authenticate
   - **Error handling**: Provide specific, actionable error messages that guide users to fix configuration issues
 - **API Version:** Prioritize v2 endpoints where available, fallback to v1 if needed.

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,7 +4,7 @@
 
 - The module will function as a backend Node-RED integration for Viessmann devices via the official SaaS API.
 - It will allow users to:
-  - Authenticate (OAuth2 client credentials or device flow).
+  - Use a Viessmann account that has been authenticated out-of-band via the OAuth2 Authorization Code with PKCE flow (see §2a). The runtime never performs the browser-based login itself.
   - Discover available Viessmann devices (gateways, installations, equipment, features).
   - Read any available data point/parameter.
   - Set writable parameters (e.g., desired temperature, operation modes: on/off, etc.).
@@ -15,23 +15,35 @@
 ## 2. Node-RED Node Designs
 
 ### a) Configuration Node: `viessmann-config`
-- Stores API credentials (client_id, client_secret, etc.) securely.
-- Handles authentication/token refresh.
+- Stores the public client ID and the pre-obtained access/refresh tokens securely via Node-RED's credential system.
+- Owns the runtime token lifecycle: validates the stored access token, refreshes it via the refresh token, and surfaces auth state to dependent nodes.
 - Provides config for all Viessmann nodes.
+- **Does not perform interactive authentication itself.** Token bootstrap is an out-of-band step handled by `scripts/get-viessmann-tokens.js` (see §2.0).
 
 **OAuth2 Configuration:**
-- **Grant Type**: Client credentials flow
-- **Scopes**: Default is `IoT offline_access`
-- **Token Endpoint**: `https://iam.viessmann.com/idp/v3/token`
+- **Grant Type at runtime**: Refresh token grant (the access token is renewed using the stored refresh token).
+- **Grant Type at bootstrap**: Authorization Code with PKCE (run via `scripts/get-viessmann-tokens.js`).
+- **Public client**: no `client_secret` (PKCE replaces it).
+- **Scopes**: `IoT offline_access` (the `offline_access` scope is what makes refresh tokens issuable).
+- **IAM endpoint**: `https://iam.viessmann-climatesolutions.com/idp/v3/token`
 
 **External Requirements:**
 Users must obtain credentials from the Viessmann Developer Portal:
-1. Create a client/application in the Developer Portal
-2. Obtain Client ID (and Client Secret if provided)
-3. Refer to [Viessmann API Authentication Documentation](https://api.viessmann-climatesolutions.com/documentation/static/authentication) for detailed setup instructions
+1. Create a client/application in the Developer Portal.
+2. Obtain a Client ID. Viessmann's developer flow is now a public PKCE client - **no Client Secret is issued**.
+3. Set the client's redirect URI to `http://localhost:4200/` so the bootstrap script's local callback can complete.
+4. Run the bootstrap script (§2.0) to obtain access + refresh tokens, then paste them into the config node.
 
-**Inputs:** (credentials via Node-RED credential system)  
+Refer to the [Viessmann API Authentication Documentation](https://api.viessmann-climatesolutions.com/documentation/static/authentication) for further detail.
+
+**Inputs:** (credentials via Node-RED credential system)
 **Outputs:** (none; used as shared config)
+
+### 2.0 Token Bootstrap CLI: `scripts/get-viessmann-tokens.js`
+- A standalone Node.js script that performs the Authorization Code with PKCE flow against Viessmann's IAM.
+- Generates a code verifier/challenge, opens the user's browser, captures the redirect on a local loopback callback server, and exchanges the authorization code for access and refresh tokens.
+- Prints both tokens to stdout for the user to paste into the `viessmann-config` node.
+- This step is **not** part of the Node-RED runtime: it is a one-time setup the user runs from a terminal.
 
 ### b) Device Discovery Node: `viessmann-device-list`
 - Lists all accessible installations, gateways, devices, and their features.
@@ -66,9 +78,9 @@ Users must obtain credentials from the Viessmann Developer Portal:
 
 ## 3. Key Implementation Decisions
 
-- **Authentication:** Use OAuth2 PKCE flow with scopes (`IoT offline_access` by default); token refresh managed by config node.
+- **Authentication:** Authorization Code with PKCE for bootstrap (via `scripts/get-viessmann-tokens.js`); refresh-token grant at runtime (in `viessmann-config`). Default scopes: `IoT offline_access`. Concurrent refresh attempts are de-duplicated via an in-flight promise so the IdP's refresh-token rotation cannot race-invalidate the stored token.
   - **Scopes are configurable**: Users can modify scopes if needed for their specific use case
-  - **External setup required**: Users must obtain credentials from the Viessmann Developer Portal
+  - **External setup required**: Users must obtain a Client ID from the Viessmann Developer Portal and run the bootstrap CLI before the Node-RED config node can authenticate
   - **Error handling**: Provide specific, actionable error messages that guide users to fix configuration issues
 - **API Version:** Prioritize v2 endpoints where available, fallback to v1 if needed.
 - **Error Handling:** All nodes must emit errors via Node-RED convention (`node.error()`), provide informative feedback with troubleshooting guidance.
@@ -90,8 +102,8 @@ Users must obtain credentials from the Viessmann Developer Portal:
 
 - **API Quotas & Rate Limits:** The module must respect Viessmann API limits.
 - **Device/Feature Variability:** Not all devices will expose the same features or writable parameters; dynamic discovery & validation is required.
-- **OAuth2 Flow & External Setup:** 
-  - Client credentials flow is used
-  - **Users must obtain credentials** from the Viessmann Developer Portal before authentication will work
+- **OAuth2 Flow & External Setup:**
+  - Authorization Code with PKCE is used for bootstrap; refresh-token grant at runtime
+  - **Users must obtain a Client ID** from the Viessmann Developer Portal and run `scripts/get-viessmann-tokens.js` to mint the initial access + refresh tokens before the Node-RED config node can authenticate
   - Refer to Viessmann API documentation for detailed setup requirements
   - Error messages guide users to fix configuration issues


### PR DESCRIPTION
Closes #64.

## Summary
Docs-only fix. SPEC.md and README.md no longer disagree with the code.

- **SPEC §1, §2a, §3, Obstacles** rewritten to describe what's actually implemented: Authorization Code with PKCE for bootstrap; refresh-token grant at runtime; public client (no client_secret); concurrent-refresh de-dup.
- **New SPEC §2.0** documents the token-bootstrap CLI (`scripts/get-viessmann-tokens.js`) as an explicit out-of-band step — that constraint deserves explicit acknowledgement.
- **Token endpoint** corrected from `iam.viessmann.com` to `iam.viessmann-climatesolutions.com`.
- **README features list** updated to describe the actual flow (was "client credentials or device flow").

## Internal multi-perspective review
- **Code quality** — docs reads more accurately; no code change.
- **Architecture** — surfaces a real constraint (bootstrap is out-of-band) that previous SPEC concealed.
- **Security** — clarifies "public client / no client_secret" so users don't paste secrets where none exist.
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 176 passing (unchanged, docs-only)