### PR TITLE
Fix wrong IAM host in test mocks + extract URL constants (#65, #84)

### DIFF
--- a/nodes/lib/client.js
+++ b/nodes/lib/client.js
@@ -19,6 +19,9 @@
 const axios = require('axios');
 
 const VIESSMANN_API_BASE_URL = 'https://api.viessmann-climatesolutions.com';
+const VIESSMANN_IAM_BASE_URL = 'https://iam.viessmann-climatesolutions.com';
+const VIESSMANN_TOKEN_PATH = '/idp/v3/token';
+const VIESSMANN_AUTHORIZE_PATH = '/idp/v3/authorize';
 const HTTP_TIMEOUT_MS = 30000;
 
 const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
@@ -290,6 +293,9 @@ class ViessmannClient {
 module.exports = {
     ViessmannClient,
     VIESSMANN_API_BASE_URL,
+    VIESSMANN_IAM_BASE_URL,
+    VIESSMANN_TOKEN_PATH,
+    VIESSMANN_AUTHORIZE_PATH,
     HTTP_TIMEOUT_MS,
     RETRYABLE_STATUSES,
     MAX_RETRIES,

--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -1,5 +1,10 @@
 const axios = require('axios');
-const { ViessmannClient, HTTP_TIMEOUT_MS } = require('./lib/client');
+const {
+    ViessmannClient,
+    HTTP_TIMEOUT_MS,
+    VIESSMANN_IAM_BASE_URL,
+    VIESSMANN_TOKEN_PATH
+} = require('./lib/client');
 
 // Token refresh buffer time (5 minutes before expiration)
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
@@ -29,7 +34,7 @@ module.exports = function(RED) {
         this.enableDebug = config.enableDebug || false;
         
         // OAuth2 endpoints
-        this.tokenUrl = 'https://iam.viessmann-climatesolutions.com/idp/v3/token';
+        this.tokenUrl = VIESSMANN_IAM_BASE_URL + VIESSMANN_TOKEN_PATH;
         
         // Token storage - initialize from credentials if provided
         this.accessToken = node.credentials.accessToken || null;

--- a/test/viessmann-config_spec.js
+++ b/test/viessmann-config_spec.js
@@ -270,7 +270,7 @@ describe('viessmann-config Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -304,7 +304,7 @@ describe('viessmann-config Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -348,7 +348,7 @@ describe('viessmann-config Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -443,7 +443,7 @@ describe('viessmann-config Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -543,7 +543,7 @@ describe('viessmann-config Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',

--- a/test/viessmann-device-features_spec.js
+++ b/test/viessmann-device-features_spec.js
@@ -44,7 +44,7 @@ describe('viessmann-device-features Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -320,7 +320,7 @@ describe('viessmann-device-features Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -376,7 +376,7 @@ describe('viessmann-device-features Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',

--- a/test/viessmann-device-features_spec.js
+++ b/test/viessmann-device-features_spec.js
@@ -43,16 +43,6 @@ describe('viessmann-device-features Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock device features endpoint
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/features/installations/123456/gateways/7571381573112225/devices/0/features')
@@ -319,16 +309,6 @@ describe('viessmann-device-features Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock device features endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/features/installations/123456/gateways/7571381573112225/devices/0/features')
@@ -375,15 +355,6 @@ describe('viessmann-device-features Node', function() {
                 refreshToken: 'test-refresh-token'
             }
         };
-
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');

--- a/test/viessmann-device-list_spec.js
+++ b/test/viessmann-device-list_spec.js
@@ -43,16 +43,6 @@ describe('viessmann-device-list Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock installations endpoint
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/equipment/installations')
@@ -162,16 +152,6 @@ describe('viessmann-device-list Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock installations endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/equipment/installations')
@@ -218,15 +198,6 @@ describe('viessmann-device-list Node', function() {
                 refreshToken: 'test-refresh-token'
             }
         };
-
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
 
         helper.load([configNode, deviceListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');

--- a/test/viessmann-device-list_spec.js
+++ b/test/viessmann-device-list_spec.js
@@ -44,7 +44,7 @@ describe('viessmann-device-list Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -163,7 +163,7 @@ describe('viessmann-device-list Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -219,7 +219,7 @@ describe('viessmann-device-list Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',

--- a/test/viessmann-gateway-devices_spec.js
+++ b/test/viessmann-gateway-devices_spec.js
@@ -43,16 +43,6 @@ describe('viessmann-gateway-devices Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock gateway devices endpoint
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/equipment/installations/123456/gateways/7571381573112225/devices')
@@ -249,16 +239,6 @@ describe('viessmann-gateway-devices Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock gateway devices endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/equipment/installations/123456/gateways/7571381573112225/devices')
@@ -305,15 +285,6 @@ describe('viessmann-gateway-devices Node', function() {
                 refreshToken: 'test-refresh-token'
             }
         };
-
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');

--- a/test/viessmann-gateway-devices_spec.js
+++ b/test/viessmann-gateway-devices_spec.js
@@ -44,7 +44,7 @@ describe('viessmann-gateway-devices Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -250,7 +250,7 @@ describe('viessmann-gateway-devices Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -306,7 +306,7 @@ describe('viessmann-gateway-devices Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',

--- a/test/viessmann-gateway-list_spec.js
+++ b/test/viessmann-gateway-list_spec.js
@@ -44,7 +44,7 @@ describe('viessmann-gateway-list Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -193,7 +193,7 @@ describe('viessmann-gateway-list Node', function() {
         };
 
         // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',
@@ -249,7 +249,7 @@ describe('viessmann-gateway-list Node', function() {
             }
         };
 
-        nock('https://iam.viessmann.com')
+        nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
             .reply(200, {
                 access_token: 'test-access-token',

--- a/test/viessmann-gateway-list_spec.js
+++ b/test/viessmann-gateway-list_spec.js
@@ -43,16 +43,6 @@ describe('viessmann-gateway-list Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock gateways endpoint
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/equipment/installations/123456/gateways')
@@ -192,16 +182,6 @@ describe('viessmann-gateway-list Node', function() {
             }
         };
 
-        // Mock OAuth2 token endpoint
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         // Mock gateways endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/equipment/installations/123456/gateways')
@@ -248,15 +228,6 @@ describe('viessmann-gateway-list Node', function() {
                 refreshToken: 'test-refresh-token'
             }
         };
-
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
 
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');


### PR DESCRIPTION
Closes #65.
Closes #84.

## Summary
- Test mocks updated from `https://iam.viessmann.com` → `https://iam.viessmann-climatesolutions.com` across five spec files.
- New constants in `nodes/lib/client.js`: `VIESSMANN_IAM_BASE_URL`, `VIESSMANN_TOKEN_PATH`, `VIESSMANN_AUTHORIZE_PATH`.
- `viessmann-config.js` now builds `tokenUrl` from the constants instead of a hard-coded literal.

## Why
- Mocks pointing at the wrong host were silently dead: any test that exercised the token-refresh path would have hit the real network (or hung).
- Hard-coding the URL in three places (config node, HTML help, bootstrap script) made the previous drift possible.

## Not in this PR
- HTML editor help text and `scripts/get-viessmann-tokens.js` still hard-code the URL. Threading the constant into the script would mean making it a node-modules dependency of the standalone CLI.
- `nock.disableNetConnect()` / `nock.isDone()` guards are left for a follow-up (intersects with test boilerplate consolidation #68 — several specs still ship unused mocks).

## Internal multi-perspective review
- **Code quality** — single source of truth for IAM URL; closes the dead-mock false confidence.
- **Architecture** — constants live in the same client module that consumes them; viessmann-config no longer duplicates the literal.
- **Security** — n/a.
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 176 passing (unchanged count; behavior intact).
- [x] `grep iam.viessmann.com` returns 0 hits in `nodes/`, `test/`, `scripts/`.