### PR TITLE
Replace shape-only read/write status tests with behavioral assertions (#66)

### DIFF
--- a/test/viessmann-read_spec.js
+++ b/test/viessmann-read_spec.js
@@ -503,15 +503,25 @@ describe('viessmann-read Node', function() {
         };
 
         helper.load([configNode, readNode], flow, credentials, function() {
-            const n1 = helper.getNode('n1');
             const c1 = helper.getNode('c1');
-            
-            expect(n1).to.have.property('updateStatus');
-            expect(typeof n1.updateStatus).to.equal('function');
-            
-            // Should be authenticated with token
-            expect(c1.authState).to.equal('authenticated');
-            done();
+            const n1 = helper.getNode('n1');
+
+            // Capture every status() call so we can assert on the actual
+            // visible icon, not just internal state.
+            const statusCalls = [];
+            const originalStatus = n1.status;
+            n1.status = function(status) {
+                statusCalls.push(status);
+                originalStatus.call(n1, status);
+            };
+
+            c1.authenticate().then(() => {
+                expect(statusCalls.length).to.be.greaterThan(0);
+                const lastStatus = statusCalls[statusCalls.length - 1];
+                expect(lastStatus.fill).to.equal('green');
+                expect(lastStatus.text).to.equal('connected');
+                done();
+            }).catch(done);
         });
     });
 
@@ -522,22 +532,29 @@ describe('viessmann-read Node', function() {
         ];
         const credentials = {
             c1: {
-                clientId: 'test-client-id',
-                accessToken: '',
-                refreshToken: ''
+                clientId: 'test-client-id'
+                // No accessToken - authenticate() will reject and push the
+                // node into the error auth state.
             }
         };
 
         helper.load([configNode, readNode], flow, credentials, function() {
-            const n1 = helper.getNode('n1');
             const c1 = helper.getNode('c1');
-            
-            expect(n1).to.have.property('updateStatus');
-            expect(typeof n1.updateStatus).to.equal('function');
-            
-            // Should be disconnected without token
-            expect(c1.authState).to.equal('disconnected');
-            done();
+            const n1 = helper.getNode('n1');
+
+            const statusCalls = [];
+            const originalStatus = n1.status;
+            n1.status = function(status) {
+                statusCalls.push(status);
+                originalStatus.call(n1, status);
+            };
+
+            c1.authenticate().catch(() => {
+                expect(statusCalls.length).to.be.greaterThan(0);
+                const lastStatus = statusCalls[statusCalls.length - 1];
+                expect(lastStatus.fill).to.equal('red');
+                done();
+            });
         });
     });
 

--- a/test/viessmann-read_spec.js
+++ b/test/viessmann-read_spec.js
@@ -550,10 +550,14 @@ describe('viessmann-read Node', function() {
             };
 
             c1.authenticate().catch(() => {
-                expect(statusCalls.length).to.be.greaterThan(0);
-                const lastStatus = statusCalls[statusCalls.length - 1];
-                expect(lastStatus.fill).to.equal('red');
-                done();
+                try {
+                    expect(statusCalls.length).to.be.greaterThan(0);
+                    const lastStatus = statusCalls[statusCalls.length - 1];
+                    expect(lastStatus.fill).to.equal('red');
+                    done();
+                } catch (err) {
+                    done(err);
+                }
             });
         });
     });

--- a/test/viessmann-write_spec.js
+++ b/test/viessmann-write_spec.js
@@ -516,15 +516,23 @@ describe('viessmann-write Node', function() {
         };
 
         helper.load([configNode, writeNode], flow, credentials, function() {
-            const n1 = helper.getNode('n1');
             const c1 = helper.getNode('c1');
-            
-            expect(n1).to.have.property('updateStatus');
-            expect(typeof n1.updateStatus).to.equal('function');
-            
-            // Should be authenticated with token
-            expect(c1.authState).to.equal('authenticated');
-            done();
+            const n1 = helper.getNode('n1');
+
+            const statusCalls = [];
+            const originalStatus = n1.status;
+            n1.status = function(status) {
+                statusCalls.push(status);
+                originalStatus.call(n1, status);
+            };
+
+            c1.authenticate().then(() => {
+                expect(statusCalls.length).to.be.greaterThan(0);
+                const lastStatus = statusCalls[statusCalls.length - 1];
+                expect(lastStatus.fill).to.equal('green');
+                expect(lastStatus.text).to.equal('connected');
+                done();
+            }).catch(done);
         });
     });
 
@@ -535,22 +543,29 @@ describe('viessmann-write Node', function() {
         ];
         const credentials = {
             c1: {
-                clientId: 'test-client-id',
-                accessToken: '',
-                refreshToken: ''
+                clientId: 'test-client-id'
+                // No accessToken - authenticate() rejects, push the node
+                // into the error auth state.
             }
         };
 
         helper.load([configNode, writeNode], flow, credentials, function() {
-            const n1 = helper.getNode('n1');
             const c1 = helper.getNode('c1');
-            
-            expect(n1).to.have.property('updateStatus');
-            expect(typeof n1.updateStatus).to.equal('function');
-            
-            // Should be disconnected without token
-            expect(c1.authState).to.equal('disconnected');
-            done();
+            const n1 = helper.getNode('n1');
+
+            const statusCalls = [];
+            const originalStatus = n1.status;
+            n1.status = function(status) {
+                statusCalls.push(status);
+                originalStatus.call(n1, status);
+            };
+
+            c1.authenticate().catch(() => {
+                expect(statusCalls.length).to.be.greaterThan(0);
+                const lastStatus = statusCalls[statusCalls.length - 1];
+                expect(lastStatus.fill).to.equal('red');
+                done();
+            });
         });
     });
 

--- a/test/viessmann-write_spec.js
+++ b/test/viessmann-write_spec.js
@@ -561,10 +561,14 @@ describe('viessmann-write Node', function() {
             };
 
             c1.authenticate().catch(() => {
-                expect(statusCalls.length).to.be.greaterThan(0);
-                const lastStatus = statusCalls[statusCalls.length - 1];
-                expect(lastStatus.fill).to.equal('red');
-                done();
+                try {
+                    expect(statusCalls.length).to.be.greaterThan(0);
+                    const lastStatus = statusCalls[statusCalls.length - 1];
+                    expect(lastStatus.fill).to.equal('red');
+                    done();
+                } catch (err) {
+                    done(err);
+                }
             });
         });
     });


### PR DESCRIPTION
Closes #66.

## Summary
The status tests in `viessmann-read_spec.js` and `viessmann-write_spec.js` were structural-only: they checked that `n1.updateStatus` is a function and that `c1.authState` is the expected literal, but never drove `c1.authenticate()` and never asserted on what got passed to `node.status()`. The equivalent tests in the four discovery node specs already used the right pattern.

This PR brings read/write into line with that pattern:
- Capture every `node.status(...)` call.
- Drive `c1.authenticate()` (resolve for the green-path test, reject for the error-path test).
- Assert on the captured `fill` / `text`.

## Internal multi-perspective review
- **Code quality** — same pattern as device-list/gateway-list specs; no new mock or fixture introduced.
- **Architecture** — n/a.
- **Security** — n/a.
- **Error handling** — directly tightens regression coverage on the status pipeline for the two most-used nodes.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 176 passing (unchanged count, but the two read/write tests now actually exercise the path).