### PR TITLE
Correct API paths in viessmann-write.html and viessmann-device-features.html (#67)

### DIFF
--- a/nodes/viessmann-device-features.html
+++ b/nodes/viessmann-device-features.html
@@ -66,7 +66,7 @@
         <li><code>viessmann-gateway-list</code> node to get gateway serials</li>
         <li><code>viessmann-gateway-devices</code> node to get device IDs</li>
     </ul>
-    <p>API endpoint: <code>GET /iot/v2/equipment/installations/{installationId}/gateways/{gatewaySerial}/devices/{deviceId}/features</code></p>
+    <p>API endpoint: <code>GET /iot/v2/features/installations/{installationId}/gateways/{gatewaySerial}/devices/{deviceId}/features</code></p>
     
     <h3>Error Handling</h3>
     <p>The node will emit an error if:</p>

--- a/nodes/viessmann-write.html
+++ b/nodes/viessmann-write.html
@@ -75,7 +75,7 @@
     </ul>
     
     <h3>API Endpoint</h3>
-    <p>Uses: <code>POST /iot/v2/equipment/installations/{installationId}/gateways/{gatewaySerial}/devices/{deviceId}/features/{feature}/commands/{command}</code></p>
+    <p>Uses: <code>POST /iot/v2/features/installations/{installationId}/gateways/{gatewaySerial}/devices/{deviceId}/features/{feature}/commands/{command}</code></p>
     
     <h3>Examples</h3>
     <p><strong>Setting operation mode:</strong></p>


### PR DESCRIPTION
Closes #67.

## Summary
Two HTML help blocks documented `/iot/v2/equipment/...` but the implementation actually calls `/iot/v2/features/...`. Fixed in place.

Other HTML files (`device-list`, `gateway-list`, `gateway-devices`) accurately document `/iot/v2/equipment/...` — those endpoints really are equipment-scoped — so no change needed there.

## Internal multi-perspective review
- **Code quality** — docs now match code; no code change.
- **Architecture** — confirms the equipment vs features endpoint split is intentional; #67 follow-up suggestion (lift endpoint paths into constants) deferred.
- **Security** — n/a.
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 176 passing (unchanged, docs-only).