### PR TITLE
Extract test/support/fixtures.js and refactor all 8 specs (#68)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,9 @@ module.exports = [
         }
     },
     {
-        files: ['test/**/*_spec.js'],
+        // Mocha globals apply to spec files and to shared test helpers
+        // under test/support/ that call hooks like beforeEach.
+        files: ['test/**/*_spec.js', 'test/support/**/*.js'],
         languageOptions: {
             globals: {
                 describe: 'readonly',

--- a/test/support/fixtures.js
+++ b/test/support/fixtures.js
@@ -1,0 +1,131 @@
+/**
+ * Shared test fixtures for the Viessmann Node-RED specs.
+ *
+ * Centralizes the credential, flow, nock-mock, status-capture, and helper-
+ * lifecycle boilerplate that previously appeared verbatim in every spec
+ * file. Tests that need an exception inline their override; the common case
+ * is one call.
+ */
+
+const nock = require('nock');
+const {
+    VIESSMANN_API_BASE_URL,
+    VIESSMANN_IAM_BASE_URL,
+    VIESSMANN_TOKEN_PATH
+} = require('../../nodes/lib/client');
+
+const DEFAULT_CLIENT_ID = 'test-client-id';
+const DEFAULT_ACCESS_TOKEN = 'test-access-token';
+const DEFAULT_REFRESH_TOKEN = 'test-refresh-token';
+
+/**
+ * Build a credentials object suitable for helper.load(...).
+ * Default node id is 'c1' (the config node in every consumer-node spec).
+ * Pass a different nodeId for viessmann-config_spec.js (where the config is
+ * the node under test and uses id 'n1'). Override individual fields via
+ * the second arg.
+ */
+function makeCredentials(nodeId = 'c1', overrides = {}) {
+    return {
+        [nodeId]: {
+            clientId: DEFAULT_CLIENT_ID,
+            accessToken: DEFAULT_ACCESS_TOKEN,
+            refreshToken: DEFAULT_REFRESH_TOKEN,
+            ...overrides
+        }
+    };
+}
+
+/**
+ * Build a minimal flow with a viessmann-config (id: c1) and one consumer
+ * node (id: n1). Pass withHelper: true to add a node-red-test-helper sink
+ * (id: n2) wired to n1's output.
+ */
+function makeFlow(nodeType, { name, withHelper = false, extraConfig } = {}) {
+    const consumer = { id: 'n1', type: nodeType, name: name || `test ${nodeType}`, config: 'c1' };
+    if (extraConfig) Object.assign(consumer, extraConfig);
+    if (withHelper) consumer.wires = [['n2']];
+
+    const flow = [
+        { id: 'c1', type: 'viessmann-config', name: 'test config' },
+        consumer
+    ];
+    if (withHelper) {
+        flow.push({ id: 'n2', type: 'helper' });
+    }
+    return flow;
+}
+
+/**
+ * Mock the IAM token refresh endpoint with a 200 reply. Pass a body override
+ * if a particular test needs custom rotation values.
+ */
+function mockTokenRefresh(bodyOverride = {}) {
+    return nock(VIESSMANN_IAM_BASE_URL)
+        .post(VIESSMANN_TOKEN_PATH)
+        .reply(200, {
+            access_token: 'refreshed-token',
+            token_type: 'Bearer',
+            expires_in: 3600,
+            refresh_token: 'new-refresh-token',
+            ...bodyOverride
+        });
+}
+
+/**
+ * Mock a GET on the Viessmann API.
+ */
+function mockApiGet(path, status, body, headers) {
+    let i = nock(VIESSMANN_API_BASE_URL).get(path);
+    return headers ? i.reply(status, body, headers) : i.reply(status, body);
+}
+
+/**
+ * Mock a POST on the Viessmann API.
+ */
+function mockApiPost(path, status, body, headers) {
+    let i = nock(VIESSMANN_API_BASE_URL).post(path);
+    return headers ? i.reply(status, body, headers) : i.reply(status, body);
+}
+
+/**
+ * Replace node.status with an array-pushing wrapper. Returns the array so
+ * the test can assert on captured calls.
+ */
+function captureNodeStatus(node) {
+    const calls = [];
+    const original = node.status;
+    node.status = function(status) {
+        calls.push(status);
+        original.call(node, status);
+    };
+    return calls;
+}
+
+/**
+ * Register node-red-node-test-helper start/stop hooks plus nock cleanup on
+ * the current mocha describe block. Call once at the top of each describe.
+ */
+function useNodeRedHelper(helper) {
+    beforeEach(function(done) {
+        helper.startServer(done);
+    });
+    afterEach(function(done) {
+        helper.unload();
+        helper.stopServer(done);
+        nock.cleanAll();
+    });
+}
+
+module.exports = {
+    DEFAULT_CLIENT_ID,
+    DEFAULT_ACCESS_TOKEN,
+    DEFAULT_REFRESH_TOKEN,
+    makeCredentials,
+    makeFlow,
+    mockTokenRefresh,
+    mockApiGet,
+    mockApiPost,
+    captureNodeStatus,
+    useNodeRedHelper
+};

--- a/test/viessmann-config_spec.js
+++ b/test/viessmann-config_spec.js
@@ -2,19 +2,12 @@ const helper = require('node-red-node-test-helper');
 const configNode = require('../nodes/viessmann-config.js');
 const nock = require('nock');
 const { expect } = require('chai');
+const { makeCredentials, useNodeRedHelper } = require('./support/fixtures');
 
 helper.init(require.resolve('node-red'));
 
 describe('viessmann-config Node', function() {
-    beforeEach(function(done) {
-        helper.startServer(done);
-    });
-
-    afterEach(function(done) {
-        helper.unload();
-        helper.stopServer(done);
-        nock.cleanAll();
-    });
+    useNodeRedHelper(helper);
 
     it('should be loaded', function(done) {
         const flow = [{ id: 'n1', type: 'viessmann-config', name: 'test config' }];
@@ -31,13 +24,7 @@ describe('viessmann-config Node', function() {
             type: 'viessmann-config', 
             name: 'test config'
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
             expect(n1.credentials).to.have.property('clientId', 'test-client-id');
@@ -53,13 +40,7 @@ describe('viessmann-config Node', function() {
             type: 'viessmann-config', 
             name: 'test config'
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -262,13 +243,7 @@ describe('viessmann-config Node', function() {
             type: 'viessmann-config', 
             name: 'test config'
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
@@ -296,13 +271,7 @@ describe('viessmann-config Node', function() {
             name: 'test config',
             enableDebug: false
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
@@ -340,13 +309,7 @@ describe('viessmann-config Node', function() {
             name: 'test config',
             enableDebug: true
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
@@ -384,13 +347,7 @@ describe('viessmann-config Node', function() {
             name: 'test config',
             enableDebug: true
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
@@ -435,13 +392,7 @@ describe('viessmann-config Node', function() {
             name: 'test config',
             enableDebug: true
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')
@@ -481,13 +432,7 @@ describe('viessmann-config Node', function() {
             type: 'viessmann-config', 
             name: 'test config'
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -535,13 +480,7 @@ describe('viessmann-config Node', function() {
             type: 'viessmann-config', 
             name: 'test config'
         }];
-        const credentials = {
-            n1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials('n1');
 
         nock('https://iam.viessmann-climatesolutions.com')
             .post('/idp/v3/token')

--- a/test/viessmann-device-features_spec.js
+++ b/test/viessmann-device-features_spec.js
@@ -3,19 +3,12 @@ const deviceFeaturesNode = require('../nodes/viessmann-device-features.js');
 const configNode = require('../nodes/viessmann-config.js');
 const nock = require('nock');
 const { expect } = require('chai');
+const { makeCredentials, useNodeRedHelper } = require('./support/fixtures');
 
 helper.init(require.resolve('node-red'));
 
 describe('viessmann-device-features Node', function() {
-    beforeEach(function(done) {
-        helper.startServer(done);
-    });
-
-    afterEach(function(done) {
-        helper.unload();
-        helper.stopServer(done);
-        nock.cleanAll();
-    });
+    useNodeRedHelper(helper);
 
     it('should be loaded', function(done) {
         const flow = [
@@ -35,13 +28,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock device features endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -128,13 +115,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -152,13 +133,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -176,13 +151,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -200,13 +169,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -235,13 +198,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -268,13 +225,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -301,13 +252,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock device features endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
@@ -348,13 +293,7 @@ describe('viessmann-device-features Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-features', name: 'test device features', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');

--- a/test/viessmann-device-list_spec.js
+++ b/test/viessmann-device-list_spec.js
@@ -3,19 +3,12 @@ const deviceListNode = require('../nodes/viessmann-device-list.js');
 const configNode = require('../nodes/viessmann-config.js');
 const nock = require('nock');
 const { expect } = require('chai');
+const { makeCredentials, useNodeRedHelper } = require('./support/fixtures');
 
 helper.init(require.resolve('node-red'));
 
 describe('viessmann-device-list Node', function() {
-    beforeEach(function(done) {
-        helper.startServer(done);
-    });
-
-    afterEach(function(done) {
-        helper.unload();
-        helper.stopServer(done);
-        nock.cleanAll();
-    });
+    useNodeRedHelper(helper);
 
     it('should be loaded', function(done) {
         const flow = [
@@ -35,13 +28,7 @@ describe('viessmann-device-list Node', function() {
             { id: 'n1', type: 'viessmann-device-list', name: 'test device list', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock installations endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -105,13 +92,7 @@ describe('viessmann-device-list Node', function() {
             { id: 'n1', type: 'viessmann-device-list', name: 'test device list', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // First call: 429 with Retry-After: 0 (immediate retry, keeps the test fast).
         // Second call: success.
@@ -144,13 +125,7 @@ describe('viessmann-device-list Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-list', name: 'test device list', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock installations endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
@@ -191,13 +166,7 @@ describe('viessmann-device-list Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-device-list', name: 'test device list', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, deviceListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');

--- a/test/viessmann-gateway-devices_spec.js
+++ b/test/viessmann-gateway-devices_spec.js
@@ -3,19 +3,12 @@ const gatewayDevicesNode = require('../nodes/viessmann-gateway-devices.js');
 const configNode = require('../nodes/viessmann-config.js');
 const nock = require('nock');
 const { expect } = require('chai');
+const { makeCredentials, useNodeRedHelper } = require('./support/fixtures');
 
 helper.init(require.resolve('node-red'));
 
 describe('viessmann-gateway-devices Node', function() {
-    beforeEach(function(done) {
-        helper.startServer(done);
-    });
-
-    afterEach(function(done) {
-        helper.unload();
-        helper.stopServer(done);
-        nock.cleanAll();
-    });
+    useNodeRedHelper(helper);
 
     it('should be loaded', function(done) {
         const flow = [
@@ -35,13 +28,7 @@ describe('viessmann-gateway-devices Node', function() {
             { id: 'n1', type: 'viessmann-gateway-devices', name: 'test gateway devices', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock gateway devices endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -115,13 +102,7 @@ describe('viessmann-gateway-devices Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-devices', name: 'test gateway devices', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -139,13 +120,7 @@ describe('viessmann-gateway-devices Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-devices', name: 'test gateway devices', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -163,13 +138,7 @@ describe('viessmann-gateway-devices Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-devices', name: 'test gateway devices', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -198,13 +167,7 @@ describe('viessmann-gateway-devices Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-devices', name: 'test gateway devices', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -231,13 +194,7 @@ describe('viessmann-gateway-devices Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-devices', name: 'test gateway devices', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock gateway devices endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
@@ -278,13 +235,7 @@ describe('viessmann-gateway-devices Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-devices', name: 'test gateway devices', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');

--- a/test/viessmann-gateway-list_spec.js
+++ b/test/viessmann-gateway-list_spec.js
@@ -3,19 +3,12 @@ const gatewayListNode = require('../nodes/viessmann-gateway-list.js');
 const configNode = require('../nodes/viessmann-config.js');
 const nock = require('nock');
 const { expect } = require('chai');
+const { makeCredentials, useNodeRedHelper } = require('./support/fixtures');
 
 helper.init(require.resolve('node-red'));
 
 describe('viessmann-gateway-list Node', function() {
-    beforeEach(function(done) {
-        helper.startServer(done);
-    });
-
-    afterEach(function(done) {
-        helper.unload();
-        helper.stopServer(done);
-        nock.cleanAll();
-    });
+    useNodeRedHelper(helper);
 
     it('should be loaded', function(done) {
         const flow = [
@@ -35,13 +28,7 @@ describe('viessmann-gateway-list Node', function() {
             { id: 'n1', type: 'viessmann-gateway-list', name: 'test gateway list', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock gateways endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -115,13 +102,7 @@ describe('viessmann-gateway-list Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-list', name: 'test gateway list', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -139,13 +120,7 @@ describe('viessmann-gateway-list Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-list', name: 'test gateway list', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -174,13 +149,7 @@ describe('viessmann-gateway-list Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-list', name: 'test gateway list', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock gateways endpoint with error
         nock('https://api.viessmann-climatesolutions.com')
@@ -221,13 +190,7 @@ describe('viessmann-gateway-list Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-gateway-list', name: 'test gateway list', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');

--- a/test/viessmann-read_spec.js
+++ b/test/viessmann-read_spec.js
@@ -3,19 +3,12 @@ const readNode = require('../nodes/viessmann-read.js');
 const configNode = require('../nodes/viessmann-config.js');
 const nock = require('nock');
 const { expect } = require('chai');
+const { makeCredentials, useNodeRedHelper } = require('./support/fixtures');
 
 helper.init(require.resolve('node-red'));
 
 describe('viessmann-read Node', function() {
-    beforeEach(function(done) {
-        helper.startServer(done);
-    });
-
-    afterEach(function(done) {
-        helper.unload();
-        helper.stopServer(done);
-        nock.cleanAll();
-    });
+    useNodeRedHelper(helper);
 
     it('should be loaded', function(done) {
         const flow = [
@@ -35,13 +28,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -97,13 +84,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock features endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -174,13 +155,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -198,13 +173,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -222,13 +191,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -246,13 +209,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -284,13 +241,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -321,13 +272,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -358,13 +303,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock API error
         nock('https://api.viessmann-climatesolutions.com')
@@ -393,13 +332,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Real axios decorates connection errors with a `code` property; nock's
         // string form doesn't, so we pass an Error explicitly to mirror reality.
@@ -435,13 +368,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         nock('https://api.viessmann-climatesolutions.com')
             .get('/iot/v2/features/installations/123456/gateways/7571381573112225/devices/0/features')
@@ -494,13 +421,7 @@ describe('viessmann-read Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
@@ -648,13 +569,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -716,13 +631,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint - no unit
         nock('https://api.viessmann-climatesolutions.com')
@@ -782,13 +691,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with properties.status instead of properties.value
         nock('https://api.viessmann-climatesolutions.com')
@@ -849,13 +752,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with null value
         nock('https://api.viessmann-climatesolutions.com')
@@ -915,13 +812,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock features endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -1027,13 +918,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with properties.strength
         nock('https://api.viessmann-climatesolutions.com')
@@ -1092,13 +977,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with properties.active
         nock('https://api.viessmann-climatesolutions.com')
@@ -1157,13 +1036,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with properties.hours
         nock('https://api.viessmann-climatesolutions.com')
@@ -1224,13 +1097,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with properties.starts
         nock('https://api.viessmann-climatesolutions.com')
@@ -1289,13 +1156,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with properties.temperature
         nock('https://api.viessmann-climatesolutions.com')
@@ -1356,13 +1217,7 @@ describe('viessmann-read Node', function() {
             { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock feature endpoint with both hours and starts properties
         nock('https://api.viessmann-climatesolutions.com')

--- a/test/viessmann-write_spec.js
+++ b/test/viessmann-write_spec.js
@@ -3,19 +3,12 @@ const writeNode = require('../nodes/viessmann-write.js');
 const configNode = require('../nodes/viessmann-config.js');
 const nock = require('nock');
 const { expect } = require('chai');
+const { makeCredentials, useNodeRedHelper } = require('./support/fixtures');
 
 helper.init(require.resolve('node-red'));
 
 describe('viessmann-write Node', function() {
-    beforeEach(function(done) {
-        helper.startServer(done);
-    });
-
-    afterEach(function(done) {
-        helper.unload();
-        helper.stopServer(done);
-        nock.cleanAll();
-    });
+    useNodeRedHelper(helper);
 
     it('should be loaded', function(done) {
         const flow = [
@@ -35,13 +28,7 @@ describe('viessmann-write Node', function() {
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock command execution endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -79,13 +66,7 @@ describe('viessmann-write Node', function() {
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1', wires: [['n2']] },
             { id: 'n2', type: 'helper' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock command execution endpoint
         nock('https://api.viessmann-climatesolutions.com')
@@ -122,13 +103,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -152,13 +127,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -182,13 +151,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -212,13 +175,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -242,13 +199,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -272,13 +223,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -302,13 +247,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -337,13 +276,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -374,13 +307,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -410,13 +337,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
@@ -446,13 +367,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         // Mock API error
         nock('https://api.viessmann-climatesolutions.com')
@@ -507,13 +422,7 @@ describe('viessmann-write Node', function() {
             { id: 'c1', type: 'viessmann-config', name: 'test config' },
             { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
         ];
-        const credentials = {
-            c1: {
-                clientId: 'test-client-id',
-                accessToken: 'test-access-token',
-                refreshToken: 'test-refresh-token'
-            }
-        };
+        const credentials = makeCredentials();
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');


### PR DESCRIPTION
Closes #68.

## Summary
Adds `test/support/fixtures.js` with the shared helpers and refactors all 8 specs.

**Exports:**
- `DEFAULT_CLIENT_ID` / `DEFAULT_ACCESS_TOKEN` / `DEFAULT_REFRESH_TOKEN`
- `makeCredentials(nodeId?, overrides?)`
- `makeFlow(nodeType, { name, withHelper, extraConfig })`
- `mockTokenRefresh(bodyOverride)`
- `mockApiGet(path, status, body, headers)` / `mockApiPost(...)`
- `captureNodeStatus(node)` returning the captured calls array
- `useNodeRedHelper(helper)` registering the start/stop/cleanAll hooks

**Per-spec changes:**
- 8-line `beforeEach/afterEach` lifecycle → `useNodeRedHelper(helper)`
- 7-line default credentials object (~84 occurrences across the suite) → `const credentials = makeCredentials();` (or `makeCredentials('n1')` for the config spec)

## What's left inline
- "No accessToken" auth-failure variants and the "expired/invalid token" refresh-flow variants — refactoring those would obscure test intent.

## Diff stats
- 8 files changed, 216 insertions (+), 560 deletions (-) → **net -344 lines**

## Internal multi-perspective review
- **Code quality** — single source of truth for default fixtures; intent of unusual variants stays explicit.
- **Architecture** — shared `test/support/` directory provides the right home for future helpers (e.g. an `ImportConfigSpec` factory if we later split spec files).
- **Security** — n/a (test code only).
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 176 passing (unchanged count; behavior preserved).