### PR TITLE
Redact token-endpoint error body in debug logs (#79)

### DIFF
--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -221,16 +221,29 @@ module.exports = function(RED) {
                     debugLog('Token refresh failed with error: ' + error.message);
                     if (error.response) {
                         debugLog('Error status: ' + error.response.status);
-                        // Only log known-safe OAuth error fields. Avoid
-                        // JSON.stringify(error.response.data) since some IdPs
-                        // echo the submitted refresh_token/client credentials
-                        // back in the error body, and Node-RED logs commonly
-                        // land in journalctl / shipped log aggregators.
+                        // Only log a small allowlist of OAuth error fields.
+                        // Avoid JSON.stringify(error.response.data) because
+                        // some IdPs echo submitted parameters back in the
+                        // error body, and Node-RED logs often land in
+                        // journalctl / syslog / log aggregators.
+                        //
+                        // Even within the allowlist, error_description can
+                        // contain reflected values - defensively redact the
+                        // current refresh token and client id from it.
                         const data = error.response.data || {};
                         const safe = {};
                         if (data.error !== undefined) safe.error = data.error;
-                        if (data.error_description !== undefined) safe.error_description = data.error_description;
                         if (data.error_uri !== undefined) safe.error_uri = data.error_uri;
+                        if (data.error_description !== undefined) {
+                            let desc = String(data.error_description);
+                            if (node.refreshToken) {
+                                desc = desc.split(node.refreshToken).join(maskSensitiveData(node.refreshToken));
+                            }
+                            if (node.credentials.clientId) {
+                                desc = desc.split(node.credentials.clientId).join(maskSensitiveData(node.credentials.clientId));
+                            }
+                            safe.error_description = desc;
+                        }
                         debugLog('Error fields: ' + JSON.stringify(safe));
                     }
                     const errorMsg = error.response?.data?.error_description || error.message;

--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -221,7 +221,17 @@ module.exports = function(RED) {
                     debugLog('Token refresh failed with error: ' + error.message);
                     if (error.response) {
                         debugLog('Error status: ' + error.response.status);
-                        debugLog('Error data: ' + JSON.stringify(error.response.data));
+                        // Only log known-safe OAuth error fields. Avoid
+                        // JSON.stringify(error.response.data) since some IdPs
+                        // echo the submitted refresh_token/client credentials
+                        // back in the error body, and Node-RED logs commonly
+                        // land in journalctl / shipped log aggregators.
+                        const data = error.response.data || {};
+                        const safe = {};
+                        if (data.error !== undefined) safe.error = data.error;
+                        if (data.error_description !== undefined) safe.error_description = data.error_description;
+                        if (data.error_uri !== undefined) safe.error_uri = data.error_uri;
+                        debugLog('Error fields: ' + JSON.stringify(safe));
                     }
                     const errorMsg = error.response?.data?.error_description || error.message;
                     const fullErrorMsg = 'Token refresh failed: ' + errorMsg + '. You may need to generate new tokens.';


### PR DESCRIPTION
Closes #79.

## Summary
The token-refresh debug log previously serialized the entire response body via `JSON.stringify(error.response.data)`. Several OAuth IdPs echo submitted parameters back in `invalid_grant` errors — Node-RED logs commonly land in journalctl / syslog / log aggregators where that defeats the masking the rest of the refresh path does.

This PR allowlists the three RFC 6749 OAuth error fields (`error`, `error_description`, `error_uri`) and logs only those.

## Internal multi-perspective review
- **Code quality** — same flow, fewer characters logged.
- **Architecture** — n/a.
- **Security** — closes the leak. Logs still describe what went wrong; secrets cannot ride along.
- **Error handling** — debug content shrinks but the error.message itself is still logged (above this block) and the rejection still propagates.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 176 passing (unchanged).