### PR TITLE
Surface non-axios errors instead of swallowing them in node catches (#70)

### DIFF
--- a/nodes/viessmann-device-features.js
+++ b/nodes/viessmann-device-features.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannDeviceFeaturesNode(config) {
@@ -23,8 +23,8 @@ module.exports = function(RED) {
                 // Set payload to the features data
                 msg.payload = response.data.data || [];
                 node.send(msg);
-            } catch (_error) {
-                // Error already handled by executeApiGet
+            } catch (error) {
+                handlePostApiError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-device-features.js
+++ b/nodes/viessmann-device-features.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannDeviceFeaturesNode(config) {
@@ -10,21 +10,25 @@ module.exports = function(RED) {
             const ref = validateViessmannRef(node, msg);
             if (!ref) return;
             const { installationId, gatewaySerial, deviceId } = ref;
-                        
+
+            let response;
             try {
-                const response = await executeApiGet(
+                response = await executeApiGet(
                     node,
                     msg,
                     `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features`,
                     'fetching...',
                     'Failed to fetch device features'
                 );
-                
-                // Set payload to the features data
+            } catch (_apiError) {
+                return;
+            }
+
+            try {
                 msg.payload = response.data.data || [];
                 node.send(msg);
             } catch (error) {
-                handlePostApiError(node, msg, error);
+                surfaceUnexpectedError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-device-list.js
+++ b/nodes/viessmann-device-list.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannDeviceListNode(config) {
@@ -23,8 +23,8 @@ module.exports = function(RED) {
                 // Set payload to the installations data
                 msg.payload = response.data.data || [];
                 node.send(msg);
-            } catch (_error) {
-                // Error already handled by executeApiGet
+            } catch (error) {
+                handlePostApiError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-device-list.js
+++ b/nodes/viessmann-device-list.js
@@ -1,30 +1,32 @@
-const { initializeViessmannNode, validateConfigNode, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannDeviceListNode(config) {
         initializeViessmannNode(RED, this, config);
         const node = this;
-        
+
         node.on('input', async function(msg) {
-            // Check if config node is available
-            if (!validateConfigNode(node, msg)) {
-                return;
-            }
-            
+            if (!validateConfigNode(node, msg)) return;
+
+            let response;
             try {
-                const response = await executeApiGet(
+                response = await executeApiGet(
                     node,
                     msg,
                     `${node.apiBaseUrl}/iot/v2/equipment/installations`,
                     'fetching...',
                     'Failed to fetch installations'
                 );
-                
-                // Set payload to the installations data
+            } catch (_apiError) {
+                // executeApiGet already surfaced this via node.error.
+                return;
+            }
+
+            try {
                 msg.payload = response.data.data || [];
                 node.send(msg);
             } catch (error) {
-                handlePostApiError(node, msg, error);
+                surfaceUnexpectedError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-gateway-devices.js
+++ b/nodes/viessmann-gateway-devices.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, viessmannRefSource, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, viessmannRefSource, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannGatewayDevicesNode(config) {
@@ -13,21 +13,25 @@ module.exports = function(RED) {
             if (!installationId) return;
             const gatewaySerial = validateGatewaySerial(node, source);
             if (!gatewaySerial) return;
-                        
+
+            let response;
             try {
-                const response = await executeApiGet(
+                response = await executeApiGet(
                     node,
                     msg,
                     `${node.apiBaseUrl}/iot/v2/equipment/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices`,
                     'fetching...',
                     'Failed to fetch gateway devices'
                 );
-                
-                // Set payload to the devices data
+            } catch (_apiError) {
+                return;
+            }
+
+            try {
                 msg.payload = response.data.data || [];
                 node.send(msg);
             } catch (error) {
-                handlePostApiError(node, msg, error);
+                surfaceUnexpectedError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-gateway-devices.js
+++ b/nodes/viessmann-gateway-devices.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, viessmannRefSource, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, viessmannRefSource, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannGatewayDevicesNode(config) {
@@ -26,8 +26,8 @@ module.exports = function(RED) {
                 // Set payload to the devices data
                 msg.payload = response.data.data || [];
                 node.send(msg);
-            } catch (_error) {
-                // Error already handled by executeApiGet
+            } catch (error) {
+                handlePostApiError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-gateway-list.js
+++ b/nodes/viessmann-gateway-list.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateInstallationId, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannGatewayListNode(config) {
@@ -24,8 +24,8 @@ module.exports = function(RED) {
                 // Set payload to the gateways data
                 msg.payload = response.data.data || [];
                 node.send(msg);
-            } catch (_error) {
-                // Error already handled by executeApiGet
+            } catch (error) {
+                handlePostApiError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-gateway-list.js
+++ b/nodes/viessmann-gateway-list.js
@@ -1,31 +1,32 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateInstallationId, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannGatewayListNode(config) {
         initializeViessmannNode(RED, this, config);
         const node = this;
-        
+
         node.on('input', async function(msg) {
             const installationId = validateInstallationId(node, msg);
-            
-            if (!validateConfigNode(node, msg) || !installationId) {
-                return;
-            }
-                        
+            if (!validateConfigNode(node, msg) || !installationId) return;
+
+            let response;
             try {
-                const response = await executeApiGet(
+                response = await executeApiGet(
                     node,
                     msg,
                     `${node.apiBaseUrl}/iot/v2/equipment/installations/${encodeURIComponent(installationId)}/gateways`,
                     'fetching...',
                     'Failed to fetch gateways'
                 );
-                
-                // Set payload to the gateways data
+            } catch (_apiError) {
+                return;
+            }
+
+            try {
                 msg.payload = response.data.data || [];
                 node.send(msg);
             } catch (error) {
-                handlePostApiError(node, msg, error);
+                surfaceUnexpectedError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -301,24 +301,33 @@ function validateViessmannRef(node, msg) {
 }
 
 /**
- * Surface an exception from a node's input handler appropriately.
+ * Surface an unexpected error from the payload-processing block of a node's
+ * input handler (the block AFTER executeApiGet/Post returns).
  *
- * executeApiGet/Post already call node.error + node.status for axios
- * failures and rethrow the original error. The node-level catch is there
- * to (a) suppress those (already surfaced) and (b) surface any OTHER
- * error - a TypeError from payload processing, a JSON.stringify on a
- * cyclic body, a bug in our response shaping - that would otherwise be
- * silently swallowed.
+ * executeApiGet/Post handle their own failures (call node.error / node.status
+ * for every thrown error inside them, then rethrow). To avoid double-firing,
+ * the consumer-node pattern is:
+ *
+ *   let response;
+ *   try { response = await executeApiGet(...); }
+ *   catch (_) { return; }              // already surfaced upstream
+ *   try {
+ *     msg.payload = ...response...;
+ *     node.send(msg);
+ *   } catch (error) {
+ *     surfaceUnexpectedError(node, msg, error);
+ *   }
+ *
+ * Anything that reaches this function is something we didn't anticipate -
+ * a TypeError from accessing an unexpected response shape, a cyclic
+ * JSON.stringify, or a bug in our shaping code - and it would otherwise
+ * be silently dropped.
  *
  * @param {object} node - The Node-RED node instance
  * @param {object} msg - The incoming message
  * @param {*} error - The thrown value
  */
-function handlePostApiError(node, msg, error) {
-    if (error && error.isAxiosError) {
-        // Already surfaced via node.error inside executeApiGet/Post.
-        return;
-    }
+function surfaceUnexpectedError(node, msg, error) {
     const message = error && error.message ? error.message : String(error);
     node.status({fill: 'red', shape: 'dot', text: 'internal error'});
     node.error('Internal error: ' + message, msg);
@@ -338,7 +347,14 @@ function statusRetryReporter(node, statusText) {
 
 /**
  * Execute an API GET via the shared ViessmannClient with UI side effects
- * (status icon + node.error on failure) layered on top.
+ * layered on top.
+ *
+ * On *any* thrown error (axios or otherwise) this helper calls node.error
+ * and node.status, then rethrows. Callers should treat the rejected promise
+ * as "already surfaced" and not double-fire node.error on it. For errors
+ * that happen AFTER this returns - e.g. payload-shaping bugs - use
+ * surfaceUnexpectedError in the consumer node.
+ *
  * @param {object} node - The Node-RED node instance
  * @param {object} msg - The incoming message
  * @param {string} url - The API endpoint URL
@@ -365,6 +381,7 @@ async function executeApiGet(node, msg, url, statusText = 'fetching...', errorPr
 
 /**
  * Execute an API POST via the shared ViessmannClient with UI side effects.
+ * Same already-surfaced-on-throw contract as executeApiGet.
  */
 async function executeApiPost(node, msg, url, data, statusText = 'writing...', errorPrefix = 'Failed to write data') {
     try {
@@ -401,7 +418,7 @@ module.exports = {
     validateDeviceId,
     validateViessmannRef,
     viessmannRefSource,
-    handlePostApiError,
+    surfaceUnexpectedError,
     executeApiGet,
     executeApiPost
 };

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -301,6 +301,30 @@ function validateViessmannRef(node, msg) {
 }
 
 /**
+ * Surface an exception from a node's input handler appropriately.
+ *
+ * executeApiGet/Post already call node.error + node.status for axios
+ * failures and rethrow the original error. The node-level catch is there
+ * to (a) suppress those (already surfaced) and (b) surface any OTHER
+ * error - a TypeError from payload processing, a JSON.stringify on a
+ * cyclic body, a bug in our response shaping - that would otherwise be
+ * silently swallowed.
+ *
+ * @param {object} node - The Node-RED node instance
+ * @param {object} msg - The incoming message
+ * @param {*} error - The thrown value
+ */
+function handlePostApiError(node, msg, error) {
+    if (error && error.isAxiosError) {
+        // Already surfaced via node.error inside executeApiGet/Post.
+        return;
+    }
+    const message = error && error.message ? error.message : String(error);
+    node.status({fill: 'red', shape: 'dot', text: 'internal error'});
+    node.error('Internal error: ' + message, msg);
+}
+
+/**
  * Build a retry-wait callback that reflects the next retry's countdown in the
  * node's status icon, so users see "fetching... (HTTP 429, retry in 2s)"
  * instead of a frozen yellow ring.
@@ -377,6 +401,7 @@ module.exports = {
     validateDeviceId,
     validateViessmannRef,
     viessmannRefSource,
+    handlePostApiError,
     executeApiGet,
     executeApiPost
 };

--- a/nodes/viessmann-read.js
+++ b/nodes/viessmann-read.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannReadNode(config) {
@@ -10,40 +10,33 @@ module.exports = function(RED) {
             const ref = validateViessmannRef(node, msg);
             if (!ref) return;
             const { installationId, gatewaySerial, deviceId } = ref;
-            
+
             // Check for feature or datapoint (both are treated the same way)
             const feature = msg.feature || msg.datapoint;
-            
+            const endpoint = feature
+                ? `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}`
+                : `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features`;
+
+            let response;
             try {
-                let endpoint;
-                if (feature) {
-                    // Read specific feature
-                    endpoint = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}`;
-                } else {
-                    // Read all features
-                    endpoint = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features`;
-                }
-                
-                const response = await executeApiGet(
-                    node,
-                    msg,
-                    endpoint,
-                    'reading...',
-                    'Failed to read data'
-                );
-                
+                response = await executeApiGet(node, msg, endpoint, 'reading...', 'Failed to read data');
+            } catch (_apiError) {
+                return;
+            }
+
+            try {
                 // Set payload to the data
                 // For single feature reads, API returns { data: {...} }
                 // For all features reads, API returns { data: [...] }
                 msg.payload = response.data.data || response.data;
-                
+
                 // Set status based on the read result
                 if (feature && msg.payload.properties) {
                     // Collect values from all available property paths
                     // Order matters: check most specific/common properties first
                     const propertyNames = ['value', 'status', 'temperature', 'strength', 'active', 'hours', 'starts'];
                     const statusParts = [];
-                    
+
                     for (const propName of propertyNames) {
                         const valueObj = msg.payload.properties[propName];
                         if (valueObj && valueObj.value !== null && valueObj.value !== undefined) {
@@ -53,7 +46,7 @@ module.exports = function(RED) {
                             statusParts.push(part);
                         }
                     }
-                    
+
                     if (statusParts.length > 0) {
                         // Single feature read - show all values separated by /
                         const statusText = statusParts.join('/');
@@ -66,10 +59,10 @@ module.exports = function(RED) {
                     // All features read - show success
                     node.status({fill: 'green', shape: 'dot', text: 'success'});
                 }
-                
+
                 node.send(msg);
             } catch (error) {
-                handlePostApiError(node, msg, error);
+                surfaceUnexpectedError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-read.js
+++ b/nodes/viessmann-read.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, executeApiGet } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, handlePostApiError, executeApiGet } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannReadNode(config) {
@@ -68,8 +68,8 @@ module.exports = function(RED) {
                 }
                 
                 node.send(msg);
-            } catch (_error) {
-                // Error already handled by executeApiGet
+            } catch (error) {
+                handlePostApiError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-write.js
+++ b/nodes/viessmann-write.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, executeApiPost } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, handlePostApiError, executeApiPost } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannWriteNode(config) {
@@ -63,8 +63,8 @@ module.exports = function(RED) {
                 };
                 
                 node.send(msg);
-            } catch (_error) {
-                // Error already handled by executeApiPost
+            } catch (error) {
+                handlePostApiError(node, msg, error);
             }
         });
     }

--- a/nodes/viessmann-write.js
+++ b/nodes/viessmann-write.js
@@ -1,4 +1,4 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, handlePostApiError, executeApiPost } = require('./viessmann-helpers');
+const { initializeViessmannNode, validateConfigNode, validateViessmannRef, surfaceUnexpectedError, executeApiPost } = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannWriteNode(config) {
@@ -39,19 +39,15 @@ module.exports = function(RED) {
                 return;
             }
             
+            const endpoint = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}/commands/${encodeURIComponent(msg.command)}`;
+
             try {
-                const endpoint = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}/commands/${encodeURIComponent(msg.command)}`;
-                
-                await executeApiPost(
-                    node,
-                    msg,
-                    endpoint,
-                    msg.params,
-                    'writing...',
-                    'Failed to write data'
-                );
-                
-                // Set payload to success status
+                await executeApiPost(node, msg, endpoint, msg.params, 'writing...', 'Failed to write data');
+            } catch (_apiError) {
+                return;
+            }
+
+            try {
                 msg.payload = {
                     success: true,
                     installationId: installationId,
@@ -61,10 +57,9 @@ module.exports = function(RED) {
                     command: msg.command,
                     params: msg.params
                 };
-                
                 node.send(msg);
             } catch (error) {
-                handlePostApiError(node, msg, error);
+                surfaceUnexpectedError(node, msg, error);
             }
         });
     }

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -11,7 +11,8 @@ const {
     validateInstallationId,
     validateGatewaySerial,
     validateDeviceId,
-    validateViessmannRef
+    validateViessmannRef,
+    handlePostApiError
 } = require('../nodes/viessmann-helpers');
 
 describe('viessmann-helpers', function() {
@@ -396,6 +397,46 @@ describe('viessmann-helpers', function() {
             validateViessmannRef(node, originalMsg);
             const [, passedMsg] = node.error.firstCall.args;
             expect(passedMsg).to.equal(originalMsg);
+        });
+    });
+
+    describe('handlePostApiError', function() {
+        let node;
+        const msg = { _msgid: 'test' };
+
+        beforeEach(function() {
+            node = { status: sinon.stub(), error: sinon.stub() };
+        });
+
+        it('should ignore axios errors (already surfaced by executeApiGet/Post)', function() {
+            const axiosError = new Error('Request failed');
+            axiosError.isAxiosError = true;
+            handlePostApiError(node, msg, axiosError);
+            expect(node.error.called).to.be.false;
+            expect(node.status.called).to.be.false;
+        });
+
+        it('should surface non-axios errors via node.error with the originating msg', function() {
+            const internalError = new TypeError('Cannot read properties of null');
+            handlePostApiError(node, msg, internalError);
+            expect(node.error.calledOnce).to.be.true;
+            const [text, passedMsg] = node.error.firstCall.args;
+            expect(text).to.include('Cannot read properties of null');
+            expect(passedMsg).to.equal(msg);
+        });
+
+        it('should set a red node.status for non-axios errors', function() {
+            handlePostApiError(node, msg, new Error('boom'));
+            expect(node.status.calledOnce).to.be.true;
+            const status = node.status.firstCall.args[0];
+            expect(status.fill).to.equal('red');
+        });
+
+        it('should not crash on non-Error thrown values', function() {
+            handlePostApiError(node, msg, 'plain string');
+            expect(node.error.calledOnce).to.be.true;
+            const [text] = node.error.firstCall.args;
+            expect(text).to.include('plain string');
         });
     });
 });

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -12,7 +12,7 @@ const {
     validateGatewaySerial,
     validateDeviceId,
     validateViessmannRef,
-    handlePostApiError
+    surfaceUnexpectedError
 } = require('../nodes/viessmann-helpers');
 
 describe('viessmann-helpers', function() {
@@ -400,7 +400,7 @@ describe('viessmann-helpers', function() {
         });
     });
 
-    describe('handlePostApiError', function() {
+    describe('surfaceUnexpectedError', function() {
         let node;
         const msg = { _msgid: 'test' };
 
@@ -408,32 +408,24 @@ describe('viessmann-helpers', function() {
             node = { status: sinon.stub(), error: sinon.stub() };
         });
 
-        it('should ignore axios errors (already surfaced by executeApiGet/Post)', function() {
-            const axiosError = new Error('Request failed');
-            axiosError.isAxiosError = true;
-            handlePostApiError(node, msg, axiosError);
-            expect(node.error.called).to.be.false;
-            expect(node.status.called).to.be.false;
-        });
-
-        it('should surface non-axios errors via node.error with the originating msg', function() {
+        it('should call node.error with the originating msg', function() {
             const internalError = new TypeError('Cannot read properties of null');
-            handlePostApiError(node, msg, internalError);
+            surfaceUnexpectedError(node, msg, internalError);
             expect(node.error.calledOnce).to.be.true;
             const [text, passedMsg] = node.error.firstCall.args;
             expect(text).to.include('Cannot read properties of null');
             expect(passedMsg).to.equal(msg);
         });
 
-        it('should set a red node.status for non-axios errors', function() {
-            handlePostApiError(node, msg, new Error('boom'));
+        it('should set a red node.status', function() {
+            surfaceUnexpectedError(node, msg, new Error('boom'));
             expect(node.status.calledOnce).to.be.true;
             const status = node.status.firstCall.args[0];
             expect(status.fill).to.equal('red');
         });
 
         it('should not crash on non-Error thrown values', function() {
-            handlePostApiError(node, msg, 'plain string');
+            surfaceUnexpectedError(node, msg, 'plain string');
             expect(node.error.calledOnce).to.be.true;
             const [text] = node.error.firstCall.args;
             expect(text).to.include('plain string');


### PR DESCRIPTION
Closes #70.

## Summary
- New `handlePostApiError(node, msg, error)` in `viessmann-helpers.js`. axios errors → noop (already surfaced by `executeApiGet/Post`); anything else → `node.error('Internal error: …', msg)` + red status.
- Wired into all six consumer nodes' previously-silent `catch (_error)` blocks.
- 4 new unit tests covering the axios-vs-internal branching, status side effect, and non-Error thrown values.

## Why
A `TypeError` from `msg.payload.properties[name]` (when the API returns an unexpected shape), a `JSON.stringify` cyclic-structure error, or any future bug in the response-shaping path was being silently dropped. Status stayed on "success", no `node.error` fired, no Catch node triggered.

## Internal multi-perspective review
- **Code quality** — one shared helper; six identical call sites collapse cleanly.
- **Architecture** — keeps the layering: client raises HTTP errors → `executeApiGet/Post` surfaces them → consumer-node catch handles only the unexpected.
- **Security** — n/a.
- **Error handling** — direct fix. Unexpected errors now reach Catch nodes with the correct routing `msg`.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 180 passing (was 176; +4 handlePostApiError tests).