### PR TITLE
Validate feature/command/params via shared helpers (#72, #82)

### DIFF
--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -246,6 +246,90 @@ function validateDeviceId(node, msg) {
 }
 
 /**
+ * Validate the msg.feature / msg.datapoint field (the two are aliases).
+ * @param {object} node - The Node-RED node instance
+ * @param {object} msg - The incoming message
+ * @returns {string|null} Validated, trimmed feature name, or null on failure
+ *
+ * Side effects: node.error + node.status on failure.
+ */
+function validateFeature(node, msg) {
+    const raw = msg.feature !== undefined ? msg.feature : msg.datapoint;
+    if (raw === null || raw === undefined) {
+        node.status({fill: 'red', shape: 'dot', text: 'no feature'});
+        node.error('No feature/datapoint provided. Please provide msg.feature or msg.datapoint.', msg);
+        return null;
+    }
+    if (typeof raw !== 'string') {
+        node.status({fill: 'red', shape: 'dot', text: 'invalid feature'});
+        node.error('Invalid feature/datapoint. Must be a string.', msg);
+        return null;
+    }
+    const value = raw.trim();
+    if (value === '') {
+        node.status({fill: 'red', shape: 'dot', text: 'invalid feature'});
+        node.error('Invalid feature/datapoint. Must be a non-empty string.', msg);
+        return null;
+    }
+    return value;
+}
+
+/**
+ * Validate the msg.command field.
+ * @param {object} node - The Node-RED node instance
+ * @param {object} msg - The incoming message
+ * @returns {string|null} Validated, trimmed command, or null on failure
+ *
+ * Side effects: node.error + node.status on failure.
+ */
+function validateCommand(node, msg) {
+    if (msg.command === null || msg.command === undefined) {
+        node.status({fill: 'red', shape: 'dot', text: 'no command'});
+        node.error('No command provided. Please provide msg.command.', msg);
+        return null;
+    }
+    if (typeof msg.command !== 'string') {
+        node.status({fill: 'red', shape: 'dot', text: 'invalid command'});
+        node.error('Invalid command. Must be a string.', msg);
+        return null;
+    }
+    const value = msg.command.trim();
+    if (value === '') {
+        node.status({fill: 'red', shape: 'dot', text: 'invalid command'});
+        node.error('Invalid command. Must be a non-empty string.', msg);
+        return null;
+    }
+    return value;
+}
+
+/**
+ * Validate the msg.params field. Must be a plain object (POST body).
+ * Empty objects pass but emit a node.warn so users notice an unusual call.
+ *
+ * @param {object} node - The Node-RED node instance
+ * @param {object} msg - The incoming message
+ * @returns {object|null} The validated params object, or null on failure
+ *
+ * Side effects: node.error + node.status on failure; node.warn on empty.
+ */
+function validateParams(node, msg) {
+    if (msg.params === null || msg.params === undefined) {
+        node.status({fill: 'red', shape: 'dot', text: 'no params'});
+        node.error('No params provided. Please provide msg.params.', msg);
+        return null;
+    }
+    if (typeof msg.params !== 'object' || Array.isArray(msg.params)) {
+        node.status({fill: 'red', shape: 'dot', text: 'invalid params'});
+        node.error('Invalid params. msg.params must be a plain object (e.g., {temperature: 22}).', msg);
+        return null;
+    }
+    if (Object.keys(msg.params).length === 0 && typeof node.warn === 'function') {
+        node.warn('Posting empty msg.params - the Viessmann command will be called with no body.');
+    }
+    return msg.params;
+}
+
+/**
  * Resolve a msg into a validation-source object: prefers msg.viessmann (the new
  * preferred bundle) when present, otherwise returns the msg itself.
  *
@@ -417,6 +501,9 @@ module.exports = {
     validateGatewaySerial,
     validateDeviceId,
     validateViessmannRef,
+    validateFeature,
+    validateCommand,
+    validateParams,
     viessmannRefSource,
     surfaceUnexpectedError,
     executeApiGet,

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -254,7 +254,8 @@ function validateDeviceId(node, msg) {
  * Side effects: node.error + node.status on failure.
  */
 function validateFeature(node, msg) {
-    const raw = msg.feature !== undefined ? msg.feature : msg.datapoint;
+    // ?? so msg.feature = null also falls through to datapoint.
+    const raw = msg.feature ?? msg.datapoint;
     if (raw === null || raw === undefined) {
         node.status({fill: 'red', shape: 'dot', text: 'no feature'});
         node.error('No feature/datapoint provided. Please provide msg.feature or msg.datapoint.', msg);
@@ -318,7 +319,7 @@ function validateParams(node, msg) {
         node.error('No params provided. Please provide msg.params.', msg);
         return null;
     }
-    if (typeof msg.params !== 'object' || Array.isArray(msg.params)) {
+    if (typeof msg.params !== 'object' || Array.isArray(msg.params) || !isPlainObject(msg.params)) {
         node.status({fill: 'red', shape: 'dot', text: 'invalid params'});
         node.error('Invalid params. msg.params must be a plain object (e.g., {temperature: 22}).', msg);
         return null;
@@ -327,6 +328,17 @@ function validateParams(node, msg) {
         node.warn('Posting empty msg.params - the Viessmann command will be called with no body.');
     }
     return msg.params;
+}
+
+/**
+ * A "plain object" is a Record-style object literal: not a class instance,
+ * Date, Buffer, Map, Set, etc. Used by validateParams to reject things that
+ * pass `typeof === 'object'` but JSON-serialize unpredictably.
+ */
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object') return false;
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
 }
 
 /**

--- a/nodes/viessmann-write.js
+++ b/nodes/viessmann-write.js
@@ -1,4 +1,13 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, surfaceUnexpectedError, executeApiPost } = require('./viessmann-helpers');
+const {
+    initializeViessmannNode,
+    validateConfigNode,
+    validateViessmannRef,
+    validateFeature,
+    validateCommand,
+    validateParams,
+    surfaceUnexpectedError,
+    executeApiPost
+} = require('./viessmann-helpers');
 
 module.exports = function(RED) {
     function ViessmannWriteNode(config) {
@@ -10,39 +19,18 @@ module.exports = function(RED) {
             const ref = validateViessmannRef(node, msg);
             if (!ref) return;
             const { installationId, gatewaySerial, deviceId } = ref;
-                        
-            // Check for feature or datapoint (both are treated the same way)
-            const feature = msg.feature || msg.datapoint;
-            if (!feature) {
-                node.status({fill: 'red', shape: 'dot', text: 'no feature'});
-                node.error('No feature/datapoint provided. Please provide msg.feature or msg.datapoint.', msg);
-                return;
-            }
-            
-            // Check if command is provided
-            if (!msg.command) {
-                node.status({fill: 'red', shape: 'dot', text: 'no command'});
-                node.error('No command provided. Please provide msg.command.', msg);
-                return;
-            }
-            
-            // Check if params is provided and is an object
-            if (!msg.params) {
-                node.status({fill: 'red', shape: 'dot', text: 'no params'});
-                node.error('No params provided. Please provide msg.params.', msg);
-                return;
-            }
 
-            if (typeof msg.params !== 'object' || Array.isArray(msg.params)) {
-                node.status({fill: 'red', shape: 'dot', text: 'invalid params'});
-                node.error('Invalid params. msg.params must be a plain object (e.g., {temperature: 22}).', msg);
-                return;
-            }
-            
-            const endpoint = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}/commands/${encodeURIComponent(msg.command)}`;
+            const feature = validateFeature(node, msg);
+            if (!feature) return;
+            const command = validateCommand(node, msg);
+            if (!command) return;
+            const params = validateParams(node, msg);
+            if (!params) return;
+
+            const endpoint = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}/commands/${encodeURIComponent(command)}`;
 
             try {
-                await executeApiPost(node, msg, endpoint, msg.params, 'writing...', 'Failed to write data');
+                await executeApiPost(node, msg, endpoint, params, 'writing...', 'Failed to write data');
             } catch (_apiError) {
                 return;
             }
@@ -50,12 +38,12 @@ module.exports = function(RED) {
             try {
                 msg.payload = {
                     success: true,
-                    installationId: installationId,
-                    gatewaySerial: gatewaySerial,
-                    deviceId: deviceId,
-                    feature: feature,
-                    command: msg.command,
-                    params: msg.params
+                    installationId,
+                    gatewaySerial,
+                    deviceId,
+                    feature,
+                    command,
+                    params
                 };
                 node.send(msg);
             } catch (error) {

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -12,6 +12,9 @@ const {
     validateGatewaySerial,
     validateDeviceId,
     validateViessmannRef,
+    validateFeature,
+    validateCommand,
+    validateParams,
     surfaceUnexpectedError
 } = require('../nodes/viessmann-helpers');
 
@@ -397,6 +400,97 @@ describe('viessmann-helpers', function() {
             validateViessmannRef(node, originalMsg);
             const [, passedMsg] = node.error.firstCall.args;
             expect(passedMsg).to.equal(originalMsg);
+        });
+    });
+
+    describe('validateFeature', function() {
+        let node;
+        beforeEach(function() {
+            node = { status: sinon.stub(), error: sinon.stub() };
+        });
+
+        it('returns msg.feature when valid', function() {
+            expect(validateFeature(node, { feature: 'heating.circuits.0' })).to.equal('heating.circuits.0');
+        });
+
+        it('falls back to msg.datapoint', function() {
+            expect(validateFeature(node, { datapoint: 'heating.circuits.0' })).to.equal('heating.circuits.0');
+        });
+
+        it('prefers feature over datapoint', function() {
+            expect(validateFeature(node, { feature: 'A', datapoint: 'B' })).to.equal('A');
+        });
+
+        it('trims whitespace', function() {
+            expect(validateFeature(node, { feature: '  X  ' })).to.equal('X');
+        });
+
+        it('rejects null/undefined', function() {
+            expect(validateFeature(node, {})).to.be.null;
+            expect(node.error.calledOnce).to.be.true;
+        });
+
+        it('rejects non-string', function() {
+            expect(validateFeature(node, { feature: 42 })).to.be.null;
+        });
+
+        it('rejects empty/whitespace-only', function() {
+            expect(validateFeature(node, { feature: '   ' })).to.be.null;
+        });
+    });
+
+    describe('validateCommand', function() {
+        let node;
+        beforeEach(function() {
+            node = { status: sinon.stub(), error: sinon.stub() };
+        });
+
+        it('returns trimmed command', function() {
+            expect(validateCommand(node, { command: '  setMode  ' })).to.equal('setMode');
+        });
+
+        it('rejects null/undefined/missing', function() {
+            expect(validateCommand(node, {})).to.be.null;
+            expect(validateCommand(node, { command: null })).to.be.null;
+        });
+
+        it('rejects non-string (catches the URL-injection-via-int case)', function() {
+            expect(validateCommand(node, { command: 42 })).to.be.null;
+        });
+
+        it('rejects whitespace-only', function() {
+            expect(validateCommand(node, { command: '   ' })).to.be.null;
+        });
+    });
+
+    describe('validateParams', function() {
+        let node;
+        beforeEach(function() {
+            node = { status: sinon.stub(), error: sinon.stub(), warn: sinon.stub() };
+        });
+
+        it('returns a plain object', function() {
+            const params = { mode: 'dhw' };
+            expect(validateParams(node, { params })).to.equal(params);
+            expect(node.warn.called).to.be.false;
+        });
+
+        it('rejects missing params', function() {
+            expect(validateParams(node, {})).to.be.null;
+            expect(node.error.calledOnce).to.be.true;
+        });
+
+        it('rejects arrays', function() {
+            expect(validateParams(node, { params: [1, 2] })).to.be.null;
+        });
+
+        it('rejects non-object', function() {
+            expect(validateParams(node, { params: 'oops' })).to.be.null;
+        });
+
+        it('warns but accepts empty object', function() {
+            expect(validateParams(node, { params: {} })).to.deep.equal({});
+            expect(node.warn.calledOnce).to.be.true;
         });
     });
 

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -492,6 +492,27 @@ describe('viessmann-helpers', function() {
             expect(validateParams(node, { params: {} })).to.deep.equal({});
             expect(node.warn.calledOnce).to.be.true;
         });
+
+        it('rejects Date / Buffer / class instances (not plain objects)', function() {
+            expect(validateParams(node, { params: new Date() })).to.be.null;
+            expect(validateParams(node, { params: Buffer.from('x') })).to.be.null;
+            class Custom {}
+            expect(validateParams(node, { params: new Custom() })).to.be.null;
+        });
+
+        it('accepts Object.create(null) (prototype-less plain object)', function() {
+            const obj = Object.create(null);
+            obj.foo = 1;
+            expect(validateParams(node, { params: obj })).to.equal(obj);
+        });
+    });
+
+    describe('validateFeature null/undefined fallback', function() {
+        it('treats msg.feature=null as missing and falls through to msg.datapoint', function() {
+            const node = { status: sinon.stub(), error: sinon.stub() };
+            expect(validateFeature(node, { feature: null, datapoint: 'fallback' })).to.equal('fallback');
+            expect(node.error.called).to.be.false;
+        });
     });
 
     describe('surfaceUnexpectedError', function() {


### PR DESCRIPTION
Closes #72.
Closes #82.

## Summary
Three new validators in `viessmann-helpers.js`:
- `validateFeature(node, msg)` — `msg.feature` ?? `msg.datapoint`; trimmed; non-empty string.
- `validateCommand(node, msg)` — `msg.command`; trimmed; non-empty string. Catches the "msg.command = 42" URL-injection case from #72.
- `validateParams(node, msg)` — `msg.params`; plain object (rejects arrays). Empty object accepted but produces `node.warn`.

`viessmann-write.js` now uses these instead of four inline if-blocks. Closes #82's "inline validation breaks the helper pattern".

## Internal multi-perspective review
- **Code quality** — uniform validator shape; one error message style; one place to extend on contract change.
- **Architecture** — `viessmann-write.js` shrinks from ~25 lines of bespoke checks to four short validator calls.
- **Security** — `validateCommand` now rejects non-string values (closes the latent path where `encodeURIComponent(42)` would be templated into the URL).
- **Error handling** — same short-circuit pattern as the rest of `viessmann-helpers.js`; one `node.error` per malformed msg.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 195 passing (was 179; +16 validator tests).
- [x] Existing write integration tests ("should handle missing feature/command/params", "should handle invalid params type") still pass without modification.