### PR TITLE
Append actionable hints for 401/403/404 (#73)

### DIFF
--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -136,7 +136,9 @@ function extractErrorMessage(error) {
             || data?.error
             || (typeof data === 'string' ? data : '');
         if (status !== undefined) {
-            return detail ? `HTTP ${status}: ${detail}` : `HTTP ${status}`;
+            const base = detail ? `HTTP ${status}: ${detail}` : `HTTP ${status}`;
+            const hint = actionableStatusHint(status);
+            return hint ? `${base} - ${hint}` : base;
         }
         return detail || error.message || 'Unknown error';
     }
@@ -146,6 +148,24 @@ function extractErrorMessage(error) {
             : 'No response from server';
     }
     return error.message || 'Unknown error';
+}
+
+/**
+ * For statuses where the user's fix is well-known, return a short hint to
+ * append to the error message. Returns '' for statuses with no actionable
+ * guidance.
+ */
+function actionableStatusHint(status) {
+    switch (status) {
+        case 403:
+            return 'token lacks scope (regenerate tokens if scopes changed)';
+        case 404:
+            return 'check installationId/gatewaySerial/deviceId';
+        case 401:
+            return 'token expired or invalid (the client refreshes automatically; if this persists, regenerate tokens)';
+        default:
+            return '';
+    }
 }
 
 /**

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -119,7 +119,27 @@ describe('viessmann-helpers', function() {
             const error = {
                 response: { status: 401, data: { message: 'Invalid token' } }
             };
-            expect(extractErrorMessage(error)).to.equal('HTTP 401: Invalid token');
+            // 401 gets an actionable hint appended; assert on the prefix.
+            expect(extractErrorMessage(error)).to.match(/^HTTP 401: Invalid token/);
+        });
+
+        it('should append a 403-scope hint', function() {
+            const error = { response: { status: 403, data: { message: 'Forbidden' } } };
+            const msg = extractErrorMessage(error);
+            expect(msg).to.include('HTTP 403');
+            expect(msg).to.include('scope');
+        });
+
+        it('should append a 404-IDs hint', function() {
+            const error = { response: { status: 404, data: { message: 'Not Found' } } };
+            const msg = extractErrorMessage(error);
+            expect(msg).to.include('HTTP 404');
+            expect(msg).to.include('installationId');
+        });
+
+        it('should not append a hint for statuses without one', function() {
+            const error = { response: { status: 418, data: {} } };
+            expect(extractErrorMessage(error)).to.equal('HTTP 418');
         });
 
         it('should prefer OAuth-style error_description when present', function() {

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -119,8 +119,10 @@ describe('viessmann-helpers', function() {
             const error = {
                 response: { status: 401, data: { message: 'Invalid token' } }
             };
-            // 401 gets an actionable hint appended; assert on the prefix.
-            expect(extractErrorMessage(error)).to.match(/^HTTP 401: Invalid token/);
+            const out = extractErrorMessage(error);
+            expect(out).to.match(/^HTTP 401: Invalid token/);
+            // 401 gets an actionable hint appended; assert it's there.
+            expect(out).to.include('token expired');
         });
 
         it('should append a 403-scope hint', function() {


### PR DESCRIPTION
Closes #73.

## Summary
- `extractErrorMessage` now appends a short fix-it hint for statuses with a well-known cause:
  - **401** → "token expired or invalid (the client refreshes automatically; if this persists, regenerate tokens)"
  - **403** → "token lacks scope (regenerate tokens if scopes changed)"
  - **404** → "check installationId/gatewaySerial/deviceId"
- Other statuses are unchanged.
- Encapsulated in a new `actionableStatusHint(status)` helper.

## Internal multi-perspective review
- **Code quality** — single switch; easy to extend; localized.
- **Architecture** — n/a.
- **Security** — n/a.
- **Error handling** — direct fix. Users no longer see "HTTP 404: Not Found" without context.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 201 passing (was 198; +3 new hint tests, 1 existing test loosened to match the appended hint).