### PR TITLE
Replace registerDependent push pattern with auth-state event (#75)

### DIFF
--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -41,12 +41,14 @@ module.exports = function(RED) {
         this.refreshToken = node.credentials.refreshToken || null;
         this.tokenExpiry = null;
         
-        // Authentication state
+        // Authentication state. Read-only from outside; mutated only inside
+        // updateAuthState (which also emits the 'auth-state' event below).
         this.authState = 'disconnected'; // 'disconnected', 'authenticating', 'authenticated', 'error'
         this.authError = null;
-        
-        // List of dependent nodes
-        this.dependentNodes = [];
+
+        // Dependent nodes observe state changes via this.on('auth-state', cb)
+        // instead of the previous registerDependent / dependentNodes array.
+        // EventEmitter is inherited from the Node-RED node base.
 
         // Shared HTTP client. Owns the axios instance, retry policy, 401
         // refresh-and-retry, response cache, in-flight de-duplication, and
@@ -80,20 +82,23 @@ module.exports = function(RED) {
         };
         
         /**
-         * Update authentication state and notify dependent nodes
+         * Update authentication state and notify subscribers via the
+         * 'auth-state' event.
          * @param {string} state - New authentication state
          * @param {string} error - Optional error message
          */
         const updateAuthState = function(state, error) {
             node.authState = state;
             node.authError = error || null;
-            
-            // Notify all dependent nodes
-            node.dependentNodes.forEach(depNode => {
-                if (depNode && typeof depNode.updateStatus === 'function') {
-                    depNode.updateStatus();
-                }
-            });
+            node.emit('auth-state', { state, error: node.authError });
+        };
+
+        /**
+         * Read-only snapshot of the current auth state. Prefer this over
+         * directly accessing node.authState / node.authError.
+         */
+        this.getAuthSnapshot = function() {
+            return { state: node.authState, error: node.authError };
         };
         
         // Initialize token expiry tracking if we have an access token
@@ -103,27 +108,6 @@ module.exports = function(RED) {
             this.tokenExpiry = Date.now() + (3600 * 1000);
             updateAuthState('authenticated');
         }
-        
-        /**
-         * Register a dependent node to receive auth state updates
-         * @param {object} depNode - The dependent node to register
-         */
-        this.registerDependent = function(depNode) {
-            if (!node.dependentNodes.includes(depNode)) {
-                node.dependentNodes.push(depNode);
-            }
-        };
-        
-        /**
-         * Unregister a dependent node
-         * @param {object} depNode - The dependent node to unregister
-         */
-        this.unregisterDependent = function(depNode) {
-            const index = node.dependentNodes.indexOf(depNode);
-            if (index > -1) {
-                node.dependentNodes.splice(index, 1);
-            }
-        };
         
         /**
          * Validate that we have an access token

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -50,29 +50,34 @@ function validateConfigNode(node, msg) {
 }
 
 /**
- * Create a status update function for dependent nodes
+ * Create a status update function for dependent nodes.
+ *
+ * Accepts an optional `snapshot` argument (state, error) - the same shape
+ * the config node emits via the 'auth-state' event. Falls back to
+ * `node.config.getAuthSnapshot()` when called with no argument (e.g. the
+ * initial render).
+ *
  * @param {object} node - The Node-RED node instance
- * @returns {function} Status update function
+ * @returns {function} Status update function: (snapshot?) => void
  */
 function createStatusUpdater(node) {
-    return function() {
+    return function(snapshot) {
         if (!node.config) {
             node.status({fill: 'red', shape: 'dot', text: 'no config'});
             return;
         }
-        
-        switch (node.config.authState) {
+        const { state, error } = snapshot || node.config.getAuthSnapshot();
+
+        switch (state) {
             case 'authenticated':
                 node.status({fill: 'green', shape: 'dot', text: 'connected'});
                 break;
             case 'authenticating':
                 node.status({fill: 'yellow', shape: 'ring', text: 'authenticating...'});
                 break;
-            case 'error': {
-                const errorText = node.config.authError || 'auth failed';
-                node.status({fill: 'red', shape: 'dot', text: errorText});
+            case 'error':
+                node.status({fill: 'red', shape: 'dot', text: error || 'auth failed'});
                 break;
-            }
             case 'disconnected':
             default:
                 node.status({fill: 'grey', shape: 'ring', text: 'disconnected'});
@@ -97,9 +102,10 @@ function setupDependentNode(node) {
         return;
     }
 
-    // Subscribe via EventEmitter. We hold the bound listener so we can
-    // remove it cleanly on node close.
-    const onAuthState = function() { node.updateStatus(); };
+    // Subscribe via EventEmitter. The listener receives the snapshot payload
+    // and passes it to updateStatus so the status reflects exactly what was
+    // emitted (no second read of mutable config state).
+    const onAuthState = function(snapshot) { node.updateStatus(snapshot); };
     node.config.on('auth-state', onAuthState);
 
     // Render the current state immediately.

--- a/nodes/viessmann-helpers.js
+++ b/nodes/viessmann-helpers.js
@@ -82,25 +82,32 @@ function createStatusUpdater(node) {
 }
 
 /**
- * Setup dependent node registration with config node
+ * Subscribe a consumer node to the config node's auth-state event so its
+ * status icon reflects auth changes.
+ *
+ * Replaces the older registerDependent/dependentNodes push pattern (#75).
+ *
  * @param {object} node - The Node-RED node instance
  */
 function setupDependentNode(node) {
-    // Create and assign status update function
     node.updateStatus = createStatusUpdater(node);
-    
-    // Register with config node to receive auth state updates
-    if (node.config) {
-        node.config.registerDependent(node);
-        node.updateStatus();
-    } else {
+
+    if (!node.config) {
         node.status({fill: 'red', shape: 'dot', text: 'no config'});
+        return;
     }
-    
-    // Unregister when node is closed
+
+    // Subscribe via EventEmitter. We hold the bound listener so we can
+    // remove it cleanly on node close.
+    const onAuthState = function() { node.updateStatus(); };
+    node.config.on('auth-state', onAuthState);
+
+    // Render the current state immediately.
+    node.updateStatus();
+
     node.on('close', function() {
-        if (node.config) {
-            node.config.unregisterDependent(node);
+        if (node.config && typeof node.config.off === 'function') {
+            node.config.off('auth-state', onAuthState);
         }
     });
 }

--- a/test/viessmann-config_spec.js
+++ b/test/viessmann-config_spec.js
@@ -474,42 +474,45 @@ describe('viessmann-config Node', function() {
         });
     });
 
-    it('should notify dependent nodes on auth state change', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+    it('should emit auth-state events on auth state change', function(done) {
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = makeCredentials('n1');
 
-        nock('https://iam.viessmann-climatesolutions.com')
-            .post('/idp/v3/token')
-            .reply(200, {
-                access_token: 'test-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'test-refresh-token'
-            });
-
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
-            // Mock dependent node
-            let statusUpdateCount = 0;
-            const mockDepNode = {
-                updateStatus: function() {
-                    statusUpdateCount++;
-                }
-            };
-            
-            n1.registerDependent(mockDepNode);
-            
+
+            const events = [];
+            n1.on('auth-state', (snapshot) => events.push(snapshot));
+
             n1.authenticate().then(() => {
-                // Should have been called during authenticating and authenticated states
-                expect(statusUpdateCount).to.be.greaterThan(0);
+                // 'authenticated' was emitted on construction (stored token)
+                // and authenticate() re-emits it. Subscriber sees at least one.
+                expect(events.length).to.be.greaterThan(0);
+                expect(events[events.length - 1].state).to.equal('authenticated');
                 done();
             }).catch(done);
         });
     });
 
+    it('should expose getAuthSnapshot()', function(done) {
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
+            name: 'test config'
+        }];
+        const credentials = makeCredentials('n1');
+
+        helper.load(configNode, flow, credentials, function() {
+            const n1 = helper.getNode('n1');
+            const snapshot = n1.getAuthSnapshot();
+            expect(snapshot).to.have.property('state');
+            expect(snapshot).to.have.property('error');
+            expect(snapshot.state).to.equal('authenticated');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Closes #75.

## Summary
- `viessmann-config` now emits an `auth-state` event on every `updateAuthState` call. Snapshot is `{state, error}`.
- `setupDependentNode` in `viessmann-helpers.js` subscribes via `node.config.on('auth-state', cb)` and unsubscribes in `node.on('close', ...)`.
- Removed `registerDependent` / `unregisterDependent` / `dependentNodes` array.
- Added `node.config.getAuthSnapshot()` for one-shot reads.

## Why
The previous design was half observer + half shared state — two channels for the same coupling. Future config-node state additions only need to be added to the event payload now.

## Internal multi-perspective review
- **Code quality** — fewer LOC; idiomatic Node.js EventEmitter.
- **Architecture** — single coupling channel.
- **Security** — n/a.
- **Error handling** — n/a; observers fire the same way.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 204 passing (was 203; replaced the registerDependent test with two new tests covering the event channel and `getAuthSnapshot()`).