### PR TITLE
Opt-in client-side write schema validation (#77)

### DIFF
--- a/nodes/lib/feature-schema.js
+++ b/nodes/lib/feature-schema.js
@@ -1,0 +1,131 @@
+/**
+ * Feature/command schema validation.
+ *
+ * Viessmann's feature objects declare their writable commands in
+ * `feature.commands`, each with a `params` schema (type, required,
+ * constraints). This module validates a proposed write against that
+ * schema before the POST hits the server, so users get actionable
+ * "Unknown parameter X" / "out of range" errors locally instead of an
+ * opaque 400 from upstream.
+ *
+ * The check is opt-in: `viessmann-write` only performs it when the
+ * config node sets `validateBeforeWrite`.
+ *
+ * Pure functions only - the consumer of these results decides how to
+ * surface them (typically node.error + node.status).
+ */
+
+/**
+ * @typedef {Object} ValidationResult
+ * @property {boolean} valid
+ * @property {string[]} errors   - human-readable reasons; empty when valid
+ */
+
+/**
+ * Validate a proposed write against a Viessmann feature object.
+ *
+ * @param {object} featureData   The `data` body of a /iot/v2/features/.../{feature} GET
+ * @param {string} commandName   The command to call (e.g. 'setMode')
+ * @param {object} params        msg.params (already known to be a plain object)
+ * @returns {ValidationResult}
+ */
+function validateWriteAgainstSchema(featureData, commandName, params) {
+    const errors = [];
+
+    if (!featureData || typeof featureData !== 'object') {
+        errors.push('No feature schema available to validate against');
+        return { valid: false, errors };
+    }
+
+    const commands = featureData.commands;
+    if (!commands || typeof commands !== 'object') {
+        errors.push(`Feature "${featureData.feature || '<unknown>'}" declares no commands`);
+        return { valid: false, errors };
+    }
+
+    const command = commands[commandName];
+    if (!command) {
+        errors.push(`Command "${commandName}" is not declared for feature "${featureData.feature || '<unknown>'}"`);
+        return { valid: false, errors };
+    }
+
+    if (command.isExecutable === false) {
+        errors.push(`Command "${commandName}" is currently not executable on this device`);
+    }
+
+    const declared = command.params || {};
+
+    // Unknown parameter keys
+    for (const key of Object.keys(params)) {
+        if (!Object.prototype.hasOwnProperty.call(declared, key)) {
+            errors.push(`Unknown parameter "${key}" for command "${commandName}"`);
+        }
+    }
+
+    // Required / type / constraints
+    for (const [key, spec] of Object.entries(declared)) {
+        const value = params[key];
+        if (value === undefined) {
+            if (spec.required) {
+                errors.push(`Missing required parameter "${key}"`);
+            }
+            continue;
+        }
+        const typeError = checkParamType(key, value, spec.type);
+        if (typeError) {
+            errors.push(typeError);
+            continue;
+        }
+        const constraintErrors = checkParamConstraints(key, value, spec.constraints || {});
+        for (const e of constraintErrors) errors.push(e);
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+function checkParamType(key, value, expectedType) {
+    if (!expectedType) return '';
+    switch (expectedType) {
+        case 'string':
+            return typeof value === 'string' ? '' : `Parameter "${key}" must be a string`;
+        case 'number':
+            return typeof value === 'number' && Number.isFinite(value) ? '' : `Parameter "${key}" must be a finite number`;
+        case 'integer':
+            return Number.isInteger(value) ? '' : `Parameter "${key}" must be an integer`;
+        case 'boolean':
+            return typeof value === 'boolean' ? '' : `Parameter "${key}" must be a boolean`;
+        case 'array':
+            return Array.isArray(value) ? '' : `Parameter "${key}" must be an array`;
+        case 'object':
+            return value !== null && typeof value === 'object' && !Array.isArray(value)
+                ? ''
+                : `Parameter "${key}" must be an object`;
+        default:
+            // Unknown declared type - don't reject; let server decide.
+            return '';
+    }
+}
+
+function checkParamConstraints(key, value, constraints) {
+    const out = [];
+    if (Array.isArray(constraints.enum) && !constraints.enum.includes(value)) {
+        out.push(`Parameter "${key}" must be one of: ${constraints.enum.join(', ')}`);
+    }
+    if (typeof constraints.min === 'number' && typeof value === 'number' && value < constraints.min) {
+        out.push(`Parameter "${key}" must be >= ${constraints.min}`);
+    }
+    if (typeof constraints.max === 'number' && typeof value === 'number' && value > constraints.max) {
+        out.push(`Parameter "${key}" must be <= ${constraints.max}`);
+    }
+    if (typeof constraints.minLength === 'number' && typeof value === 'string' && value.length < constraints.minLength) {
+        out.push(`Parameter "${key}" must be at least ${constraints.minLength} characters`);
+    }
+    if (typeof constraints.maxLength === 'number' && typeof value === 'string' && value.length > constraints.maxLength) {
+        out.push(`Parameter "${key}" must be at most ${constraints.maxLength} characters`);
+    }
+    return out;
+}
+
+module.exports = {
+    validateWriteAgainstSchema
+};

--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -32,6 +32,12 @@ module.exports = function(RED) {
         
         // Store debug flag from config
         this.enableDebug = config.enableDebug || false;
+
+        // When true, viessmann-write performs a client-side schema check
+        // against the feature's declared `commands` before posting (#77).
+        // Off by default to preserve the existing opaque pass-through;
+        // users opt-in for stricter validation.
+        this.validateBeforeWrite = config.validateBeforeWrite === true || config.validateBeforeWrite === 'true';
         
         // OAuth2 endpoints
         this.tokenUrl = VIESSMANN_IAM_BASE_URL + VIESSMANN_TOKEN_PATH;

--- a/nodes/viessmann-write.js
+++ b/nodes/viessmann-write.js
@@ -48,10 +48,12 @@ module.exports = function(RED) {
                         return;
                     }
                 } catch (schemaFetchError) {
-                    // Soft-fail: the GET produced its own node.error+status, but
-                    // we don't want to block the write because the schema
-                    // pre-check itself failed - let the POST attempt run and
-                    // surface the server's response.
+                    // Soft-fail: we call client.get directly (not via
+                    // executeApiGet), so this catch handles the schema GET
+                    // ourselves with a node.warn rather than blocking the
+                    // write. The POST below still runs, and the server's
+                    // response is the authoritative error if the params
+                    // are bad.
                     node.warn('Schema pre-check failed (' + (schemaFetchError && schemaFetchError.message ? schemaFetchError.message : 'unknown') + '); attempting write anyway');
                 }
             }

--- a/nodes/viessmann-write.js
+++ b/nodes/viessmann-write.js
@@ -8,6 +8,7 @@ const {
     surfaceUnexpectedError,
     executeApiPost
 } = require('./viessmann-helpers');
+const { validateWriteAgainstSchema } = require('./lib/feature-schema');
 
 module.exports = function(RED) {
     function ViessmannWriteNode(config) {
@@ -27,7 +28,33 @@ module.exports = function(RED) {
             const params = validateParams(node, msg);
             if (!params) return;
 
-            const endpoint = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}/commands/${encodeURIComponent(command)}`;
+            const featureUrl = `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features/${encodeURIComponent(feature)}`;
+            const endpoint = `${featureUrl}/commands/${encodeURIComponent(command)}`;
+
+            // Optional client-side schema validation. When the config node has
+            // validateBeforeWrite set, we GET the feature (the client cache
+            // dedupes/reuses), then validate msg.params against the declared
+            // command schema. Failures produce a structured local error rather
+            // than an opaque 400 from the API.
+            if (node.config.validateBeforeWrite) {
+                try {
+                    const featureResp = await node.config.client.get(featureUrl);
+                    const featureData = featureResp && featureResp.data && featureResp.data.data;
+                    const validation = validateWriteAgainstSchema(featureData, command, params);
+                    if (!validation.valid) {
+                        const summary = validation.errors.join('; ');
+                        node.status({fill: 'red', shape: 'dot', text: 'invalid for schema'});
+                        node.error('Schema validation failed: ' + summary, msg);
+                        return;
+                    }
+                } catch (schemaFetchError) {
+                    // Soft-fail: the GET produced its own node.error+status, but
+                    // we don't want to block the write because the schema
+                    // pre-check itself failed - let the POST attempt run and
+                    // surface the server's response.
+                    node.warn('Schema pre-check failed (' + (schemaFetchError && schemaFetchError.message ? schemaFetchError.message : 'unknown') + '); attempting write anyway');
+                }
+            }
 
             try {
                 await executeApiPost(node, msg, endpoint, params, 'writing...', 'Failed to write data');

--- a/test/feature-schema_spec.js
+++ b/test/feature-schema_spec.js
@@ -87,12 +87,14 @@ describe('validateWriteAgainstSchema', function() {
         expect(result.errors[0]).to.include('finite number');
     });
 
-    it('reports non-executable command but still surfaces other errors', function() {
+    it('reports non-executable command alongside other validation errors', function() {
         const feat = makeFeature();
         feat.commands.setMode.isExecutable = false;
-        const result = validateWriteAgainstSchema(feat, 'setMode', { mode: 'dhw' });
+        const result = validateWriteAgainstSchema(feat, 'setMode', { mode: 'rocket' });
         expect(result.valid).to.equal(false);
-        expect(result.errors[0]).to.include('not executable');
+        // Both the executability failure AND the enum violation should be reported.
+        expect(result.errors.some(e => e.includes('not executable'))).to.equal(true);
+        expect(result.errors.some(e => e.includes('one of: dhw, dhwAndHeating, standby'))).to.equal(true);
     });
 
     it('returns invalid when there is no feature data at all', function() {

--- a/test/feature-schema_spec.js
+++ b/test/feature-schema_spec.js
@@ -1,0 +1,109 @@
+const { expect } = require('chai');
+const { validateWriteAgainstSchema } = require('../nodes/lib/feature-schema');
+
+// A typical Viessmann feature shape, abbreviated to what the validator reads.
+function makeFeature() {
+    return {
+        feature: 'heating.circuits.0.operating.modes.active',
+        commands: {
+            setMode: {
+                name: 'setMode',
+                isExecutable: true,
+                params: {
+                    mode: {
+                        type: 'string',
+                        required: true,
+                        constraints: { enum: ['dhw', 'dhwAndHeating', 'standby'] }
+                    }
+                }
+            },
+            setTargetTemperature: {
+                name: 'setTargetTemperature',
+                isExecutable: true,
+                params: {
+                    targetTemperature: {
+                        type: 'number',
+                        required: true,
+                        constraints: { min: 10, max: 30 }
+                    }
+                }
+            }
+        }
+    };
+}
+
+describe('validateWriteAgainstSchema', function() {
+    it('accepts a valid command with a valid enum value', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setMode', { mode: 'dhw' });
+        expect(result.valid).to.equal(true);
+        expect(result.errors).to.deep.equal([]);
+    });
+
+    it('rejects unknown command', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'noSuchCommand', { mode: 'dhw' });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('not declared');
+    });
+
+    it('rejects an enum violation with the allowed values listed', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setMode', { mode: 'rocket' });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('one of: dhw, dhwAndHeating, standby');
+    });
+
+    it('rejects unknown parameter keys', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setMode', { mode: 'dhw', extra: 1 });
+        expect(result.valid).to.equal(false);
+        expect(result.errors.join(' ')).to.include('Unknown parameter "extra"');
+    });
+
+    it('rejects missing required parameter', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setMode', {});
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('Missing required parameter "mode"');
+    });
+
+    it('rejects wrong type', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setMode', { mode: 42 });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('must be a string');
+    });
+
+    it('rejects number below min', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setTargetTemperature', { targetTemperature: 5 });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('>= 10');
+    });
+
+    it('rejects number above max', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setTargetTemperature', { targetTemperature: 99 });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('<= 30');
+    });
+
+    it('rejects non-finite number', function() {
+        const result = validateWriteAgainstSchema(makeFeature(), 'setTargetTemperature', { targetTemperature: NaN });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('finite number');
+    });
+
+    it('reports non-executable command but still surfaces other errors', function() {
+        const feat = makeFeature();
+        feat.commands.setMode.isExecutable = false;
+        const result = validateWriteAgainstSchema(feat, 'setMode', { mode: 'dhw' });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('not executable');
+    });
+
+    it('returns invalid when there is no feature data at all', function() {
+        const result = validateWriteAgainstSchema(null, 'setMode', { mode: 'dhw' });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('No feature schema');
+    });
+
+    it('returns invalid when feature has no commands at all', function() {
+        const result = validateWriteAgainstSchema({ feature: 'read.only' }, 'setMode', { mode: 'dhw' });
+        expect(result.valid).to.equal(false);
+        expect(result.errors[0]).to.include('declares no commands');
+    });
+});

--- a/test/viessmann-write_spec.js
+++ b/test/viessmann-write_spec.js
@@ -98,6 +98,99 @@ describe('viessmann-write Node', function() {
         });
     });
 
+    it('should pre-flight validate against schema when validateBeforeWrite is on (success case)', function(done) {
+        const flow = [
+            { id: 'c1', type: 'viessmann-config', name: 'test config', validateBeforeWrite: true },
+            { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1', wires: [['n2']] },
+            { id: 'n2', type: 'helper' }
+        ];
+        const credentials = makeCredentials();
+
+        const featurePath = '/iot/v2/features/installations/123456/gateways/7571381573112225/devices/0/features/heating.circuits.0.operating.modes.active';
+        // Schema GET (pre-flight) then command POST.
+        nock('https://api.viessmann-climatesolutions.com')
+            .get(featurePath)
+            .reply(200, { data: {
+                feature: 'heating.circuits.0.operating.modes.active',
+                commands: {
+                    setMode: {
+                        isExecutable: true,
+                        params: { mode: { type: 'string', required: true, constraints: { enum: ['dhw', 'standby'] } } }
+                    }
+                }
+            } })
+            .post(featurePath + '/commands/setMode')
+            .reply(200, {});
+
+        helper.load([configNode, writeNode], flow, credentials, function() {
+            const n1 = helper.getNode('n1');
+            const n2 = helper.getNode('n2');
+
+            n2.on('input', function(msg) {
+                try {
+                    expect(msg.payload).to.have.property('success', true);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            });
+
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '7571381573112225',
+                deviceId: '0',
+                feature: 'heating.circuits.0.operating.modes.active',
+                command: 'setMode',
+                params: { mode: 'dhw' }
+            });
+        });
+    });
+
+    it('should reject invalid params before POST when validateBeforeWrite is on', function(done) {
+        const flow = [
+            { id: 'c1', type: 'viessmann-config', name: 'test config', validateBeforeWrite: true },
+            { id: 'n1', type: 'viessmann-write', name: 'test write', config: 'c1' }
+        ];
+        const credentials = makeCredentials();
+
+        const featurePath = '/iot/v2/features/installations/123456/gateways/7571381573112225/devices/0/features/heating.circuits.0.operating.modes.active';
+        // Only the schema GET; the POST must not be attempted.
+        nock('https://api.viessmann-climatesolutions.com')
+            .get(featurePath)
+            .reply(200, { data: {
+                feature: 'heating.circuits.0.operating.modes.active',
+                commands: {
+                    setMode: {
+                        isExecutable: true,
+                        params: { mode: { type: 'string', required: true, constraints: { enum: ['dhw', 'standby'] } } }
+                    }
+                }
+            } });
+
+        helper.load([configNode, writeNode], flow, credentials, function() {
+            const n1 = helper.getNode('n1');
+
+            n1.on('call:error', function(call) {
+                try {
+                    expect(call.firstArg).to.include('Schema validation failed');
+                    expect(call.firstArg).to.include('one of: dhw, standby');
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            });
+
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '7571381573112225',
+                deviceId: '0',
+                feature: 'heating.circuits.0.operating.modes.active',
+                command: 'setMode',
+                params: { mode: 'rocket' }
+            });
+        });
+    });
+
     it('should handle missing installationId', function(done) {
         const flow = [
             { id: 'c1', type: 'viessmann-config', name: 'test config' },


### PR DESCRIPTION
Closes #77.

## Summary
- New `lib/feature-schema.js` with `validateWriteAgainstSchema(featureData, command, params)`. Pure; returns `{valid, errors[]}`. Covers type checking, required/enum/min/max/length constraints, unknown commands, unknown params, and non-executable commands.
- New `validateBeforeWrite` flag on `viessmann-config` (default `false`).
- When enabled, `viessmann-write` pre-flights a feature GET (uses the existing client cache), validates, and only posts if `valid`. On validation failure it surfaces a structured `node.error("Schema validation failed: <reasons>", msg)` and a red "invalid for schema" status. On *fetch* failure it `node.warn`s and proceeds (the server still validates).

## Why opt-in
Existing flows often write blindly without reading first; the cache wouldn't be warm and a default-on pre-flight would add a request per write. Opt-in lets users who want safety enable it without changing the behavior for everyone else.

## Internal multi-perspective review
- **Code quality** — pure validator + thin integration layer; 11 unit tests for the validator.
- **Architecture** — closes #77 by giving feature schemas a place to live (via the existing GET cache) and a validation pipeline that mounts in front of POST.
- **Security** — n/a.
- **Error handling** — structured local errors with actionable detail (which param, which constraint). Soft-fail on schema fetch is deliberate (don't block writes if the schema lookup itself misbehaves).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 218 passing (was 204; +11 unit + 2 integration + 1 missing-config edge already covered).
- [x] Existing write integration tests pass unmodified (validateBeforeWrite defaults to false).