### PR TITLE
Collapse 4 discovery nodes into defineGetNode factory (#78)

### DIFF
--- a/nodes/lib/define-get-node.js
+++ b/nodes/lib/define-get-node.js
@@ -1,0 +1,79 @@
+/**
+ * Declarative factory for read-only Viessmann GET nodes.
+ *
+ * Each consumer node was previously the same template differing only in
+ * which validators it ran and which URL it built. This factory captures
+ * that template once - validators+URL+payload-shape come in as opts -
+ * so the four discovery node files collapse to ~15 lines each.
+ *
+ * Usage:
+ *
+ *   defineGetNode(RED, {
+ *     type: 'viessmann-gateway-devices',
+ *     getContext: (node, msg) => { ... validators, return ctx or null ... },
+ *     url: (ctx) => '/iot/v2/.../devices',
+ *     statusText: 'fetching...',
+ *     errorPrefix: 'Failed to fetch gateway devices',
+ *     shapePayload: (response) => response.data.data || []
+ *   });
+ *
+ * For nodes that need a more elaborate payload pipeline (e.g.
+ * viessmann-read, which derives a status string from the response) or
+ * that POST rather than GET (e.g. viessmann-write), keep the hand-rolled
+ * input handler - the factory only covers the orthogonal-GET shape.
+ */
+
+const { initializeViessmannNode, executeApiGet, surfaceUnexpectedError } = require('./node-runtime');
+
+/**
+ * @param {object} RED - The Node-RED runtime
+ * @param {object} opts
+ * @param {string} opts.type - Node-RED type id (e.g. 'viessmann-gateway-devices')
+ * @param {(node: object, msg: object) => object|null} opts.getContext
+ *   Run validators against msg. Return the context object (e.g. {installationId, gatewaySerial})
+ *   or null to short-circuit (validators emit their own node.error/status).
+ * @param {(ctx: object) => string} opts.url
+ *   Build the API path (relative; the factory prepends node.apiBaseUrl).
+ * @param {string} [opts.statusText] - Yellow-state text during the request.
+ * @param {string} [opts.errorPrefix] - Prefix for node.error on failure.
+ * @param {(response: object, ctx: object) => *} [opts.shapePayload]
+ *   Map the axios response into msg.payload. Defaults to `response.data.data || []`.
+ */
+function defineGetNode(RED, opts) {
+    if (!opts || !opts.type || typeof opts.getContext !== 'function' || typeof opts.url !== 'function') {
+        throw new TypeError('defineGetNode requires { type, getContext, url } at minimum');
+    }
+    const statusText = opts.statusText || 'fetching...';
+    const errorPrefix = opts.errorPrefix || 'Failed to fetch data';
+    const shapePayload = opts.shapePayload || ((response) => response.data.data || []);
+
+    function ViessmannGetNode(config) {
+        initializeViessmannNode(RED, this, config);
+        const node = this;
+
+        node.on('input', async function(msg) {
+            const ctx = opts.getContext(node, msg);
+            if (!ctx) return;
+
+            const url = `${node.apiBaseUrl}${opts.url(ctx)}`;
+
+            let response;
+            try {
+                response = await executeApiGet(node, msg, url, statusText, errorPrefix);
+            } catch (_apiError) {
+                return;
+            }
+
+            try {
+                msg.payload = shapePayload(response, ctx);
+                node.send(msg);
+            } catch (error) {
+                surfaceUnexpectedError(node, msg, error);
+            }
+        });
+    }
+
+    RED.nodes.registerType(opts.type, ViessmannGetNode);
+}
+
+module.exports = { defineGetNode };

--- a/nodes/lib/define-get-node.js
+++ b/nodes/lib/define-get-node.js
@@ -43,9 +43,18 @@ function defineGetNode(RED, opts) {
     if (!opts || !opts.type || typeof opts.getContext !== 'function' || typeof opts.url !== 'function') {
         throw new TypeError('defineGetNode requires { type, getContext, url } at minimum');
     }
-    const statusText = opts.statusText || 'fetching...';
-    const errorPrefix = opts.errorPrefix || 'Failed to fetch data';
-    const shapePayload = opts.shapePayload || ((response) => response.data.data || []);
+    if (opts.statusText !== undefined && typeof opts.statusText !== 'string') {
+        throw new TypeError('defineGetNode opts.statusText must be a string');
+    }
+    if (opts.errorPrefix !== undefined && typeof opts.errorPrefix !== 'string') {
+        throw new TypeError('defineGetNode opts.errorPrefix must be a string');
+    }
+    if (opts.shapePayload !== undefined && typeof opts.shapePayload !== 'function') {
+        throw new TypeError('defineGetNode opts.shapePayload must be a function');
+    }
+    const statusText = opts.statusText !== undefined ? opts.statusText : 'fetching...';
+    const errorPrefix = opts.errorPrefix !== undefined ? opts.errorPrefix : 'Failed to fetch data';
+    const shapePayload = opts.shapePayload !== undefined ? opts.shapePayload : ((response) => response.data.data || []);
 
     function ViessmannGetNode(config) {
         initializeViessmannNode(RED, this, config);

--- a/nodes/viessmann-device-features.js
+++ b/nodes/viessmann-device-features.js
@@ -1,37 +1,16 @@
-const { initializeViessmannNode, validateConfigNode, validateViessmannRef, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
+const { defineGetNode } = require('./lib/define-get-node');
+const { validateConfigNode, validateViessmannRef } = require('./lib/validators');
 
 module.exports = function(RED) {
-    function ViessmannDeviceFeaturesNode(config) {
-        initializeViessmannNode(RED, this, config);
-        const node = this;
-
-        node.on('input', async function(msg) {
-            if (!validateConfigNode(node, msg)) return;
-            const ref = validateViessmannRef(node, msg);
-            if (!ref) return;
-            const { installationId, gatewaySerial, deviceId } = ref;
-
-            let response;
-            try {
-                response = await executeApiGet(
-                    node,
-                    msg,
-                    `${node.apiBaseUrl}/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features`,
-                    'fetching...',
-                    'Failed to fetch device features'
-                );
-            } catch (_apiError) {
-                return;
-            }
-
-            try {
-                msg.payload = response.data.data || [];
-                node.send(msg);
-            } catch (error) {
-                surfaceUnexpectedError(node, msg, error);
-            }
-        });
-    }
-    
-    RED.nodes.registerType("viessmann-device-features", ViessmannDeviceFeaturesNode);
+    defineGetNode(RED, {
+        type: 'viessmann-device-features',
+        getContext: (node, msg) => {
+            if (!validateConfigNode(node, msg)) return null;
+            return validateViessmannRef(node, msg);
+        },
+        url: ({ installationId, gatewaySerial, deviceId }) =>
+            `/iot/v2/features/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices/${encodeURIComponent(deviceId)}/features`,
+        statusText: 'fetching...',
+        errorPrefix: 'Failed to fetch device features'
+    });
 };

--- a/nodes/viessmann-device-list.js
+++ b/nodes/viessmann-device-list.js
@@ -1,35 +1,12 @@
-const { initializeViessmannNode, validateConfigNode, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
+const { defineGetNode } = require('./lib/define-get-node');
+const { validateConfigNode } = require('./lib/validators');
 
 module.exports = function(RED) {
-    function ViessmannDeviceListNode(config) {
-        initializeViessmannNode(RED, this, config);
-        const node = this;
-
-        node.on('input', async function(msg) {
-            if (!validateConfigNode(node, msg)) return;
-
-            let response;
-            try {
-                response = await executeApiGet(
-                    node,
-                    msg,
-                    `${node.apiBaseUrl}/iot/v2/equipment/installations`,
-                    'fetching...',
-                    'Failed to fetch installations'
-                );
-            } catch (_apiError) {
-                // executeApiGet already surfaced this via node.error.
-                return;
-            }
-
-            try {
-                msg.payload = response.data.data || [];
-                node.send(msg);
-            } catch (error) {
-                surfaceUnexpectedError(node, msg, error);
-            }
-        });
-    }
-    
-    RED.nodes.registerType("viessmann-device-list", ViessmannDeviceListNode);
+    defineGetNode(RED, {
+        type: 'viessmann-device-list',
+        getContext: (node, msg) => (validateConfigNode(node, msg) ? {} : null),
+        url: () => '/iot/v2/equipment/installations',
+        statusText: 'fetching...',
+        errorPrefix: 'Failed to fetch installations'
+    });
 };

--- a/nodes/viessmann-gateway-devices.js
+++ b/nodes/viessmann-gateway-devices.js
@@ -1,40 +1,27 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, validateGatewaySerial, viessmannRefSource, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
+const { defineGetNode } = require('./lib/define-get-node');
+const {
+    validateConfigNode,
+    validateInstallationId,
+    validateGatewaySerial,
+    viessmannRefSource
+} = require('./lib/validators');
 
 module.exports = function(RED) {
-    function ViessmannGatewayDevicesNode(config) {
-        initializeViessmannNode(RED, this, config);
-        const node = this;
-
-        node.on('input', async function(msg) {
-            if (!validateConfigNode(node, msg)) return;
-            // Accept the new msg.viessmann bundle or legacy individual fields.
+    defineGetNode(RED, {
+        type: 'viessmann-gateway-devices',
+        getContext: (node, msg) => {
+            if (!validateConfigNode(node, msg)) return null;
+            // Accept the msg.viessmann bundle or legacy individual fields.
             const source = viessmannRefSource(msg);
             const installationId = validateInstallationId(node, source);
-            if (!installationId) return;
+            if (!installationId) return null;
             const gatewaySerial = validateGatewaySerial(node, source);
-            if (!gatewaySerial) return;
-
-            let response;
-            try {
-                response = await executeApiGet(
-                    node,
-                    msg,
-                    `${node.apiBaseUrl}/iot/v2/equipment/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices`,
-                    'fetching...',
-                    'Failed to fetch gateway devices'
-                );
-            } catch (_apiError) {
-                return;
-            }
-
-            try {
-                msg.payload = response.data.data || [];
-                node.send(msg);
-            } catch (error) {
-                surfaceUnexpectedError(node, msg, error);
-            }
-        });
-    }
-    
-    RED.nodes.registerType("viessmann-gateway-devices", ViessmannGatewayDevicesNode);
+            if (!gatewaySerial) return null;
+            return { installationId, gatewaySerial };
+        },
+        url: ({ installationId, gatewaySerial }) =>
+            `/iot/v2/equipment/installations/${encodeURIComponent(installationId)}/gateways/${encodeURIComponent(gatewaySerial)}/devices`,
+        statusText: 'fetching...',
+        errorPrefix: 'Failed to fetch gateway devices'
+    });
 };

--- a/nodes/viessmann-gateway-list.js
+++ b/nodes/viessmann-gateway-list.js
@@ -1,35 +1,18 @@
-const { initializeViessmannNode, validateConfigNode, validateInstallationId, surfaceUnexpectedError, executeApiGet } = require('./viessmann-helpers');
+const { defineGetNode } = require('./lib/define-get-node');
+const { validateConfigNode, validateInstallationId } = require('./lib/validators');
 
 module.exports = function(RED) {
-    function ViessmannGatewayListNode(config) {
-        initializeViessmannNode(RED, this, config);
-        const node = this;
-
-        node.on('input', async function(msg) {
+    defineGetNode(RED, {
+        type: 'viessmann-gateway-list',
+        getContext: (node, msg) => {
+            if (!validateConfigNode(node, msg)) return null;
             const installationId = validateInstallationId(node, msg);
-            if (!validateConfigNode(node, msg) || !installationId) return;
-
-            let response;
-            try {
-                response = await executeApiGet(
-                    node,
-                    msg,
-                    `${node.apiBaseUrl}/iot/v2/equipment/installations/${encodeURIComponent(installationId)}/gateways`,
-                    'fetching...',
-                    'Failed to fetch gateways'
-                );
-            } catch (_apiError) {
-                return;
-            }
-
-            try {
-                msg.payload = response.data.data || [];
-                node.send(msg);
-            } catch (error) {
-                surfaceUnexpectedError(node, msg, error);
-            }
-        });
-    }
-    
-    RED.nodes.registerType("viessmann-gateway-list", ViessmannGatewayListNode);
+            if (!installationId) return null;
+            return { installationId };
+        },
+        url: ({ installationId }) =>
+            `/iot/v2/equipment/installations/${encodeURIComponent(installationId)}/gateways`,
+        statusText: 'fetching...',
+        errorPrefix: 'Failed to fetch gateways'
+    });
 };


### PR DESCRIPTION
Closes #78.

## Summary
- New `lib/define-get-node.js` exporting `defineGetNode(RED, opts)` — declarative factory for read-only Viessmann GET nodes.
- The four discovery nodes (`device-list`, `gateway-list`, `gateway-devices`, `device-features`) now consist of a single `defineGetNode(...)` call each.
- `read` and `write` are intentionally left untouched — they have divergent payload pipelines that don't fit the orthogonal-GET shape.

## Diff stats
- 4 discovery node files: ~140 LOC → 73 LOC.
- New factory: ~80 LOC (including JSDoc).

## Internal multi-perspective review
- **Code quality** — declarative; new endpoints become 5-line additions.
- **Architecture** — direct fix for #78. Read/write left alone so the abstraction doesn't try to be everything.
- **Security** — no behavior change.
- **Error handling** — preserved verbatim: validators short-circuit on null context; `executeApiGet` surfaces the API error and the factory's outer catch returns; payload-processing errors flow through `surfaceUnexpectedError`.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 218 passing (unchanged; existing integration tests cover all four refactored nodes).