### PR TITLE
Bound the PKCE callback-server wait to 5 minutes (#86)

### DIFF
--- a/scripts/get-viessmann-tokens.js
+++ b/scripts/get-viessmann-tokens.js
@@ -25,6 +25,10 @@ const HTTP_TIMEOUT_MS = 30000;
 // discoverable next to wherever the user ran the script from.
 const DEFAULT_TOKEN_FILE = 'viessmann-tokens.json';
 
+// Max time to wait for the OAuth callback. If the user closes the browser
+// or never logs in, the script should not hang forever.
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
 const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -56,6 +60,13 @@ function generatePKCE() {
 function startCallbackServer(port, expectedState) {
     return new Promise((resolve, reject) => {
         const allowedHosts = new Set([`localhost:${port}`, `127.0.0.1:${port}`]);
+        let settled = false;
+        const settle = (fn, value) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeoutHandle);
+            fn(value);
+        };
 
         const server = http.createServer((req, res) => {
             // Reject anything that didn't come through our loopback origin.
@@ -81,7 +92,7 @@ function startCallbackServer(port, expectedState) {
                     </html>
                 `);
                 server.close();
-                resolve(code);
+                settle(resolve, code);
             } else {
                 res.writeHead(400, { 'Content-Type': 'text/plain' });
                 res.end('Invalid authorization callback (missing code or state mismatch)');
@@ -97,8 +108,16 @@ function startCallbackServer(port, expectedState) {
                 console.error(`\nError: Port ${port} is already in use.`);
                 console.error('Please close any applications using this port and try again.');
             }
-            reject(err);
+            settle(reject, err);
         });
+
+        // Bound the wait. If the user never completes the flow, fail with a
+        // clear error rather than hanging forever.
+        const timeoutHandle = setTimeout(() => {
+            server.close();
+            const minutes = Math.round(CALLBACK_TIMEOUT_MS / 60000);
+            settle(reject, new Error(`No authorization callback received within ${minutes} minutes; aborting.`));
+        }, CALLBACK_TIMEOUT_MS);
     });
 }
 

--- a/scripts/get-viessmann-tokens.js
+++ b/scripts/get-viessmann-tokens.js
@@ -61,10 +61,15 @@ function startCallbackServer(port, expectedState) {
     return new Promise((resolve, reject) => {
         const allowedHosts = new Set([`localhost:${port}`, `127.0.0.1:${port}`]);
         let settled = false;
+        // Declared with let so settle() can read it during the TDZ-safe
+        // window. Assigned at the bottom of this function; if a server
+        // 'error' fires before that, timeoutHandle is still undefined
+        // and clearTimeout(undefined) is a noop.
+        let timeoutHandle;
         const settle = (fn, value) => {
             if (settled) return;
             settled = true;
-            clearTimeout(timeoutHandle);
+            if (timeoutHandle) clearTimeout(timeoutHandle);
             fn(value);
         };
 
@@ -113,7 +118,7 @@ function startCallbackServer(port, expectedState) {
 
         // Bound the wait. If the user never completes the flow, fail with a
         // clear error rather than hanging forever.
-        const timeoutHandle = setTimeout(() => {
+        timeoutHandle = setTimeout(() => {
             server.close();
             const minutes = Math.round(CALLBACK_TIMEOUT_MS / 60000);
             settle(reject, new Error(`No authorization callback received within ${minutes} minutes; aborting.`));


### PR DESCRIPTION
Closes #86.

## Summary
- New `CALLBACK_TIMEOUT_MS` constant (5 minutes).
- `startCallbackServer` now sets a timer; if no valid callback arrives, the server is closed and the promise rejects with a clear "No authorization callback received within N minutes" error.
- Small `settle()` helper prevents double-resolve/double-reject if the timeout races a late callback.

## Internal multi-perspective review
- **Code quality** — single bounded path; small `settle` helper avoids a class of subtle bugs.
- **Architecture** — n/a.
- **Security** — n/a (server still bound to loopback, state still validated).
- **Error handling** — direct fix: no more silent hang.

## Test plan
- [x] `npm run lint` clean
- [x] `node --check` clean
- [x] `npm test` — 218 passing
- Script is an interactive CLI; behavioral validation of the timeout path would need an isolated network fixture.