### PR TITLE
Surface unexpected API shapes via node.warn (#88)

### DIFF
--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -195,7 +195,18 @@ module.exports = function(RED) {
                         node.credentials.refreshToken = response.data.refresh_token;
                         debugLog('Updated refresh token in credentials for persistence: ' + maskSensitiveData(response.data.refresh_token));
                     }
-                    node.tokenExpiry = Date.now() + (response.data.expires_in * 1000);
+                    // The IdP normally returns expires_in (RFC 6749 §4.2.2).
+                    // If it's missing we'd otherwise compute tokenExpiry = NaN,
+                    // which would silently disable future expiry-based refreshes
+                    // (NaN comparisons are always false). Warn the user and
+                    // default to a conservative 1-hour expiry.
+                    const expiresInSeconds = Number(response.data.expires_in);
+                    const validExpiresIn = Number.isFinite(expiresInSeconds) && expiresInSeconds > 0;
+                    if (!validExpiresIn) {
+                        node.warn('Token refresh response did not include a valid expires_in; assuming 1 hour.');
+                    }
+                    const effectiveExpiresIn = validExpiresIn ? expiresInSeconds : 3600;
+                    node.tokenExpiry = Date.now() + (effectiveExpiresIn * 1000);
 
                     const expiryDate = new Date(node.tokenExpiry);
                     debugLog('Token refresh successful');
@@ -203,7 +214,7 @@ module.exports = function(RED) {
                     if (response.data.refresh_token) {
                         debugLog('New refresh token: ' + maskSensitiveData(node.refreshToken));
                     }
-                    debugLog('Token expires in: ' + response.data.expires_in + ' seconds (' + expiryDate.toISOString() + ')');
+                    debugLog('Token expires in: ' + effectiveExpiresIn + ' seconds (' + expiryDate.toISOString() + ')');
 
                     node.log('Successfully refreshed access token and updated credentials');
                     updateAuthState('authenticated');

--- a/nodes/viessmann-read.js
+++ b/nodes/viessmann-read.js
@@ -25,10 +25,17 @@ module.exports = function(RED) {
             }
 
             try {
-                // Set payload to the data
                 // For single feature reads, API returns { data: {...} }
                 // For all features reads, API returns { data: [...] }
-                msg.payload = response.data.data || response.data;
+                // If the response shape is unexpected (missing data.data),
+                // surface a node.warn so users notice rather than silently
+                // handing the caller the whole envelope.
+                if (response.data && response.data.data !== undefined && response.data.data !== null) {
+                    msg.payload = response.data.data;
+                } else {
+                    node.warn('Unexpected response shape: response.data.data missing, returning envelope');
+                    msg.payload = response.data;
+                }
 
                 // Set status based on the read result
                 if (feature && msg.payload.properties) {

--- a/test/viessmann-config_spec.js
+++ b/test/viessmann-config_spec.js
@@ -237,6 +237,38 @@ describe('viessmann-config Node', function() {
         });
     });
 
+    it('should default to a 1-hour expiry and warn when expires_in is missing', function(done) {
+        const flow = [{ id: 'n1', type: 'viessmann-config', name: 'test config' }];
+        const credentials = makeCredentials('n1');
+
+        nock('https://iam.viessmann-climatesolutions.com')
+            .post('/idp/v3/token')
+            .reply(200, {
+                access_token: 'fresh-token',
+                token_type: 'Bearer'
+                // No expires_in
+            });
+
+        helper.load(configNode, flow, credentials, function() {
+            const n1 = helper.getNode('n1');
+            const warnings = [];
+            const origWarn = n1.warn;
+            n1.warn = function(m) { warnings.push(String(m)); origWarn.call(n1, m); };
+
+            const before = Date.now();
+            n1.refreshAccessToken().then(() => {
+                try {
+                    expect(warnings.some(w => w.includes('expires_in'))).to.equal(true);
+                    // Expiry should be ~1 hour from now (allow generous tolerance).
+                    const elapsed = n1.tokenExpiry - before;
+                    expect(elapsed).to.be.greaterThan(3600 * 1000 - 5000);
+                    expect(elapsed).to.be.lessThan(3600 * 1000 + 5000);
+                    done();
+                } catch (err) { done(err); }
+            }).catch(done);
+        });
+    });
+
     it('should provide valid token to requesting nodes', function(done) {
         const flow = [{ 
             id: 'n1', 

--- a/test/viessmann-read_spec.js
+++ b/test/viessmann-read_spec.js
@@ -78,6 +78,45 @@ describe('viessmann-read Node', function() {
         });
     });
 
+    it('should warn and return envelope when response.data.data is missing', function(done) {
+        const flow = [
+            { id: 'c1', type: 'viessmann-config', name: 'test config' },
+            { id: 'n1', type: 'viessmann-read', name: 'test read', config: 'c1', wires: [['n2']] },
+            { id: 'n2', type: 'helper' }
+        ];
+        const credentials = makeCredentials();
+
+        // Pathological response: 200 OK but the envelope's `data` is missing.
+        const envelope = { meta: { foo: 'bar' } };
+        nock('https://api.viessmann-climatesolutions.com')
+            .get('/iot/v2/features/installations/123456/gateways/1234567890123456/devices/0/features/heating.circuits.0.temperature')
+            .reply(200, envelope);
+
+        helper.load([configNode, readNode], flow, credentials, function() {
+            const n1 = helper.getNode('n1');
+            const n2 = helper.getNode('n2');
+
+            const warnings = [];
+            const origWarn = n1.warn;
+            n1.warn = function(m) { warnings.push(String(m)); origWarn.call(n1, m); };
+
+            n2.on('input', function(msg) {
+                try {
+                    expect(msg.payload).to.deep.equal(envelope);
+                    expect(warnings.some(w => w.toLowerCase().includes('unexpected response shape'))).to.equal(true);
+                    done();
+                } catch (err) { done(err); }
+            });
+
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
+                deviceId: '0',
+                feature: 'heating.circuits.0.temperature'
+            });
+        });
+    });
+
     it('should read all features when no feature is specified', function(done) {
         const flow = [
             { id: 'c1', type: 'viessmann-config', name: 'test config' },


### PR DESCRIPTION
Closes #88.

## Summary
Two silent fallbacks now produce a `node.warn`:

1. **`viessmann-read`** — missing `response.data.data`: warn + return the envelope (backward compatible).
2. **`viessmann-config` refresh** — missing `expires_in`: warn + default to 1-hour expiry. Without this, `Date.now() + NaN*1000 = NaN`, every expiry check returns false, and the token is treated as valid forever (until the next API call fails with 401).

## Internal multi-perspective review
- **Code quality** — small, localized.
- **Architecture** — n/a.
- **Security** — n/a.
- **Error handling** — closes a hidden correctness bug in the refresh path (NaN expiry).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 219 passing