### PR TITLE
Align Node version contract across CI / engines / README (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,7 +732,7 @@ Then restart Node-RED. The Viessmann nodes will appear in the palette.
 
 This project uses GitHub Actions for continuous integration. The CI workflow automatically:
 
-- Runs on all pushes and pull requests to `main` and `feature/**` branches
+- Runs on all pushes and pull requests targeting `main`
 - Tests on a matrix of Node.js versions (20.x, 22.x, 24.x, 26.x); minimum supported version is Node.js 20 (matches `engines` in `package.json`)
 - Installs dependencies using `npm ci`
 - Runs the linter (`npm run lint`)

--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ Then restart Node-RED. The Viessmann nodes will appear in the palette.
 This project uses GitHub Actions for continuous integration. The CI workflow automatically:
 
 - Runs on all pushes and pull requests to `main` and `feature/**` branches
-- Sets up Node.js version 20 (as specified in `package.json` engines field)
+- Tests on a matrix of Node.js versions (20.x, 22.x, 24.x, 26.x); minimum supported version is Node.js 20 (matches `engines` in `package.json`)
 - Installs dependencies using `npm ci`
 - Runs the linter (`npm run lint`)
 - Runs the test suite (`npm test`)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "axios": "^1.16.1"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Closes #90.

## Summary
- `package.json` engines bumped from `>=18.0.0` to `>=20.0.0` — Node 18 reached EOL in April 2025 and the CI matrix doesn't test it.
- README rewords the CI section: lists the matrix (20.x / 22.x / 24.x / 26.x) and clarifies that 20 is the supported floor.
- CI workflow unchanged — it already tests the right matrix.

## Internal multi-perspective review
- **Code quality** — docs and metadata now match.
- **Architecture** — single source of truth for the supported runtime.
- **Security** — n/a.
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 221 passing