### PR TITLE
Add docs-hierarchy notes (#92)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,5 +1,7 @@
 # Viessmann API Features Reference
 
+> ⚠️ **Non-authoritative.** This document is a hand-curated snapshot of the Viessmann feature catalog as of the time it was last updated. The upstream catalog evolves; the only authoritative list of features available on **your** device is what the `viessmann-device-features` node returns at runtime. Per-node I/O is documented in each node's HTML help (visible in the Node-RED editor); this file is reference-only.
+
 This document lists the features available through the Viessmann API. These features can be accessed using the `viessmann-read` and `viessmann-write` nodes.
 
 **Note:** Not all features are available on all devices. Use the `viessmann-device-features` node to discover which features are available on your specific device.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,7 @@
 # Node-RED Viessmann Module: Functional Specification
 
+> **Scope of this document.** SPEC.md captures intent and architecture decisions. For per-node I/O contracts (`msg.payload`, error behavior, status icons), the source of truth is each node's HTML help block under `nodes/*.html` — that's what users see in the Node-RED editor. README.md cross-links these; FEATURES.md is a non-authoritative catalog snapshot.
+
 ## 1. Scope
 
 - The module will function as a backend Node-RED integration for Viessmann devices via the official SaaS API.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Node-RED Viessmann Module: Functional Specification
 
-> **Scope of this document.** SPEC.md captures intent and architecture decisions. For per-node I/O contracts (`msg.payload`, error behavior, status icons), the source of truth is each node's HTML help block under `nodes/*.html` — that's what users see in the Node-RED editor. README.md cross-links these; FEATURES.md is a non-authoritative catalog snapshot.
+> **Scope of this document.** SPEC.md captures intent and architecture decisions. For per-node I/O contracts (`msg.payload`, error behavior, status icons), the source of truth is each node's HTML help block under `nodes/*.html` — that's what users see in the Node-RED editor. README.md is the install/usage guide. FEATURES.md is a non-authoritative catalog snapshot.
 
 ## 1. Scope
 


### PR DESCRIPTION
Closes #92.

## Summary
Two minimal docs markers:
- **FEATURES.md** gets a "non-authoritative snapshot" callout pointing at `viessmann-device-features` for the live list.
- **SPEC.md** gets a scope note: intent + architecture here; per-node I/O is the HTML help.

Full auto-generation of FEATURES.md and README ↔ HTML cross-linking is deferred.

## Internal multi-perspective review
- **Code quality** — docs-only.
- **Architecture** — declares the doc hierarchy; #67-class drift is harder to introduce now.
- **Security** — n/a.
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 221 passing