### PR TITLE
Enforce trailing-whitespace / blank-line rules + lint --fix (#95)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,10 @@ module.exports = [
         },
         rules: {
             'no-unused-vars': ['error', { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
-            'no-console': 'off'
+            'no-console': 'off',
+            'no-trailing-spaces': 'error',
+            'no-multiple-empty-lines': ['error', { max: 2, maxEOF: 1 }],
+            'eol-last': ['error', 'always']
         }
     },
     {

--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -29,7 +29,7 @@ module.exports = function(RED) {
     function ViessmannConfigNode(config) {
         RED.nodes.createNode(this, config);
         const node = this;
-        
+
         // Store debug flag from config
         this.enableDebug = config.enableDebug || false;
 
@@ -38,15 +38,15 @@ module.exports = function(RED) {
         // Off by default to preserve the existing opaque pass-through;
         // users opt-in for stricter validation.
         this.validateBeforeWrite = config.validateBeforeWrite === true || config.validateBeforeWrite === 'true';
-        
+
         // OAuth2 endpoints
         this.tokenUrl = VIESSMANN_IAM_BASE_URL + VIESSMANN_TOKEN_PATH;
-        
+
         // Token storage - initialize from credentials if provided
         this.accessToken = node.credentials.accessToken || null;
         this.refreshToken = node.credentials.refreshToken || null;
         this.tokenExpiry = null;
-        
+
         // Authentication state. Read-only from outside; mutated only inside
         // updateAuthState (which also emits the 'auth-state' event below).
         this.authState = 'disconnected'; // 'disconnected', 'authenticating', 'authenticated', 'error'
@@ -76,7 +76,7 @@ module.exports = function(RED) {
             if (Number.isFinite(mc) && mc >= 1) clientOptions.maxConcurrent = mc;
         }
         this.client = new ViessmannClient(node, clientOptions);
-        
+
         /**
          * Log debug information if debug mode is enabled
          * @param {string} message - The debug message to log
@@ -86,7 +86,7 @@ module.exports = function(RED) {
                 node.log('[DEBUG] ' + message);
             }
         };
-        
+
         /**
          * Update authentication state and notify subscribers via the
          * 'auth-state' event.
@@ -106,7 +106,7 @@ module.exports = function(RED) {
         this.getAuthSnapshot = function() {
             return { state: node.authState, error: node.authError };
         };
-        
+
         // Initialize token expiry tracking if we have an access token
         if (this.accessToken) {
             // Assume token expires in 1 hour (default for Viessmann) minus buffer
@@ -114,7 +114,7 @@ module.exports = function(RED) {
             this.tokenExpiry = Date.now() + (3600 * 1000);
             updateAuthState('authenticated');
         }
-        
+
         /**
          * Validate that we have an access token
          * @returns {Promise<void>}
@@ -137,7 +137,7 @@ module.exports = function(RED) {
             updateAuthState('error', errorMsg);
             throw new Error(errorMsg);
         };
-        
+
         // In-flight refresh promise. While set, concurrent callers share it
         // so we never POST /idp/v3/token twice with the same (rotating) refresh
         // token - the IdP would reject the losers and we'd race-overwrite
@@ -263,26 +263,26 @@ module.exports = function(RED) {
 
             return node._refreshPromise;
         };
-        
+
         /**
          * Get a valid access token, refreshing if necessary
          * @returns {Promise<string>} Valid access token
          */
         this.getValidToken = async function() {
             debugLog('Checking token validity');
-            
+
             // If no token exists, authenticate
             if (!node.accessToken) {
                 debugLog('No access token found, initiating authentication');
                 await node.authenticate();
                 return node.accessToken;
             }
-            
+
             // Check if token is expired (with buffer)
             const now = Date.now();
             const timeUntilExpiry = node.tokenExpiry - now;
             debugLog('Current token status: ' + Math.max(0, timeUntilExpiry) + 'ms until expiry (buffer: ' + TOKEN_REFRESH_BUFFER_MS + 'ms)');
-            
+
             if (node.tokenExpiry && now >= (node.tokenExpiry - TOKEN_REFRESH_BUFFER_MS)) {
                 debugLog('Token is expired or near expiry, refreshing');
                 if (node.refreshToken) {
@@ -295,11 +295,11 @@ module.exports = function(RED) {
             } else {
                 debugLog('Token is still valid, returning existing token');
             }
-            
+
             return node.accessToken;
         };
     }
-    
+
     RED.nodes.registerType("viessmann-config", ViessmannConfigNode, {
         credentials: {
             clientId: { type: "text" },

--- a/nodes/viessmann-read.js
+++ b/nodes/viessmann-read.js
@@ -73,6 +73,6 @@ module.exports = function(RED) {
             }
         });
     }
-    
+
     RED.nodes.registerType("viessmann-read", ViessmannReadNode);
 };

--- a/nodes/viessmann-write.js
+++ b/nodes/viessmann-write.js
@@ -93,6 +93,6 @@ module.exports = function(RED) {
             }
         });
     }
-    
+
     RED.nodes.registerType("viessmann-write", ViessmannWriteNode);
 };

--- a/scripts/get-viessmann-tokens.js
+++ b/scripts/get-viessmann-tokens.js
@@ -2,10 +2,10 @@
 
 /**
  * Viessmann Token Generator
- * 
+ *
  * This script helps you generate access and refresh tokens for the Viessmann API
  * using the OAuth2 PKCE flow.
- * 
+ *
  * Usage: node get-viessmann-tokens.js
  */
 
@@ -44,13 +44,13 @@ function question(prompt) {
 function generatePKCE() {
     // Generate a random code verifier (43-128 characters)
     const codeVerifier = crypto.randomBytes(32).toString('base64url');
-    
+
     // Generate code challenge (SHA256 hash of verifier, base64url encoded)
     const codeChallenge = crypto
         .createHash('sha256')
         .update(codeVerifier)
         .digest('base64url');
-    
+
     return { codeVerifier, codeChallenge };
 }
 
@@ -136,7 +136,7 @@ function exchangeCodeForTokens(clientId, code, codeVerifier, redirectUri) {
             code_verifier: codeVerifier,
             code: code
         });
-        
+
         const options = {
             hostname: 'iam.viessmann-climatesolutions.com',
             path: '/idp/v3/token',
@@ -146,7 +146,7 @@ function exchangeCodeForTokens(clientId, code, codeVerifier, redirectUri) {
                 'Content-Length': Buffer.byteLength(postData)
             }
         };
-        
+
         const req = https.request(options, (res) => {
             let data = '';
 
@@ -187,7 +187,7 @@ async function main() {
     console.log('='.repeat(70));
     console.log('\nThis script will help you generate access and refresh tokens');
     console.log('for use with the Node-RED Viessmann integration.\n');
-    
+
     try {
         // Get client ID
         const clientId = await question('Enter your Viessmann Client ID: ');
@@ -196,12 +196,12 @@ async function main() {
             rl.close();
             process.exit(1);
         }
-        
+
         // Generate PKCE codes
         console.log('\nGenerating PKCE code verifier and challenge...');
         const { codeVerifier, codeChallenge } = generatePKCE();
         console.log('✓ Generated');
-        
+
         // Build authorization URL with a cryptographically random state value.
         // The callback server requires the redirected state to match this, which
         // blocks LAN/CSRF code-injection attempts (see issue #69).
@@ -217,7 +217,7 @@ async function main() {
             `state=${encodeURIComponent(state)}&` +
             `code_challenge=${encodeURIComponent(codeChallenge)}&` +
             `code_challenge_method=S256`;
-        
+
         console.log('\n' + '='.repeat(70));
         console.log('STEP 1: Authorize in Browser');
         console.log('='.repeat(70));
@@ -227,7 +227,7 @@ async function main() {
         console.log('2. Authorize the application');
         console.log('3. You will be redirected to localhost (this is expected)');
         console.log('\nStarting local server to capture the authorization code...');
-        
+
         // Try to open browser. Uses execFile (array form) on a real
         // executable on every platform, so no shell parses the URL.
         // encodeURIComponent is no longer the only line of defense
@@ -247,7 +247,7 @@ async function main() {
                 execFile('xdg-open', [url], () => { /* best-effort */ });
             }
         };
-        
+
         setTimeout(() => {
             try {
                 open(authUrl);
@@ -255,19 +255,19 @@ async function main() {
                 console.log('\nCould not open browser automatically. Please open the URL manually.');
             }
         }, 1000);
-        
+
         // Start callback server and wait for code
         const code = await startCallbackServer(callbackPort, state);
         console.log('\n✓ Authorization code received');
-        
+
         // Exchange code for tokens
         console.log('\n' + '='.repeat(70));
         console.log('STEP 2: Exchanging Code for Tokens');
         console.log('='.repeat(70));
         console.log('\nRequesting access and refresh tokens...');
-        
+
         const tokens = await exchangeCodeForTokens(clientId, code, codeVerifier, redirectUri);
-        
+
         console.log('\n✓ Tokens received successfully!');
 
         // Write tokens to a restricted-permission file rather than printing
@@ -318,7 +318,7 @@ async function main() {
         console.log('\nAccess token expires in ' + (tokens.expires_in / 3600) + ' hours.');
         console.log('Refresh token expires in 180 days (used for automatic renewal).');
         console.log('='.repeat(70) + '\n');
-        
+
     } catch (err) {
         console.error('\nError:', err.message);
         process.exit(1);

--- a/test/viessmann-config_spec.js
+++ b/test/viessmann-config_spec.js
@@ -19,9 +19,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should store credentials securely', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = makeCredentials('n1');
@@ -35,16 +35,16 @@ describe('viessmann-config Node', function() {
     });
 
     it('should use provided access token', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = makeCredentials('n1');
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.authenticate().then(() => {
                 expect(n1.accessToken).to.equal('test-access-token');
                 expect(n1.refreshToken).to.equal('test-refresh-token');
@@ -104,9 +104,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should refresh token when expired', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = {
@@ -129,13 +129,13 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Token is initially loaded from credentials
             expect(n1.accessToken).to.equal('initial-token');
-            
+
             // Force token to be expired
             n1.tokenExpiry = Date.now() - 1000;
-            
+
             // getValidToken should trigger a refresh
             n1.getValidToken().then(() => {
                 expect(n1.accessToken).to.equal('refreshed-token');
@@ -146,9 +146,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should update credentials when tokens are refreshed', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = {
@@ -171,17 +171,17 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Verify initial credentials
             expect(n1.credentials.accessToken).to.equal('initial-access-token');
             expect(n1.credentials.refreshToken).to.equal('initial-refresh-token');
-            
+
             // Trigger token refresh
             n1.refreshAccessToken().then(() => {
                 // Verify that credentials are updated with new tokens
                 expect(n1.credentials.accessToken).to.equal('new-access-token');
                 expect(n1.credentials.refreshToken).to.equal('new-refresh-token');
-                
+
                 // Also verify the node properties are updated
                 expect(n1.accessToken).to.equal('new-access-token');
                 expect(n1.refreshToken).to.equal('new-refresh-token');
@@ -191,9 +191,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should update access token in credentials even when refresh token is not returned', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = {
@@ -216,19 +216,19 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Verify initial credentials
             expect(n1.credentials.accessToken).to.equal('initial-access-token');
             expect(n1.credentials.refreshToken).to.equal('initial-refresh-token');
-            
+
             // Trigger token refresh
             n1.refreshAccessToken().then(() => {
                 // Verify that access token credential is updated
                 expect(n1.credentials.accessToken).to.equal('new-access-token-only');
-                
+
                 // Verify that refresh token credential remains unchanged
                 expect(n1.credentials.refreshToken).to.equal('initial-refresh-token');
-                
+
                 // Also verify the node properties
                 expect(n1.accessToken).to.equal('new-access-token-only');
                 expect(n1.refreshToken).to.equal('initial-refresh-token');
@@ -270,9 +270,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should provide valid token to requesting nodes', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = makeCredentials('n1');
@@ -288,7 +288,7 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.getValidToken().then(token => {
                 expect(token).to.equal('test-access-token');
                 done();
@@ -297,9 +297,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should not log debug messages when debug is disabled', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config',
             enableDebug: false
         }];
@@ -316,7 +316,7 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Store original log function
             const originalLog = n1.log;
             let logMessages = [];
@@ -324,7 +324,7 @@ describe('viessmann-config Node', function() {
                 logMessages.push(msg);
                 originalLog.call(n1, msg);
             };
-            
+
             n1.authenticate().then(() => {
                 // Should only have one log message (the success message)
                 const debugLogs = logMessages.filter(msg => msg.includes('[DEBUG]'));
@@ -335,9 +335,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should log debug messages when debug is enabled', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config',
             enableDebug: true
         }];
@@ -354,7 +354,7 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Store original log function
             const originalLog = n1.log;
             let logMessages = [];
@@ -362,7 +362,7 @@ describe('viessmann-config Node', function() {
                 logMessages.push(msg);
                 originalLog.call(n1, msg);
             };
-            
+
             n1.authenticate().then(() => {
                 // Should have multiple debug log messages
                 const debugLogs = logMessages.filter(msg => msg.includes('[DEBUG]'));
@@ -373,9 +373,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should log debug messages during token refresh', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config',
             enableDebug: true
         }];
@@ -396,7 +396,7 @@ describe('viessmann-config Node', function() {
             n1.accessToken = 'old-token';
             n1.refreshToken = 'old-refresh-token';
             n1.tokenExpiry = Date.now() + 3600000;
-            
+
             // Store original log function
             const originalLog = n1.log;
             let logMessages = [];
@@ -404,23 +404,23 @@ describe('viessmann-config Node', function() {
                 logMessages.push(msg);
                 originalLog.call(n1, msg);
             };
-            
+
             n1.refreshAccessToken().then(() => {
                 const debugLogs = logMessages.filter(msg => msg.includes('[DEBUG]'));
-                
+
                 // Should have debug messages about token refresh
                 const hasRefreshMsg = debugLogs.some(msg => msg.includes('Starting token refresh'));
                 expect(hasRefreshMsg).to.be.true;
-                
+
                 done();
             }).catch(done);
         });
     });
 
     it('should log debug messages in getValidToken', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config',
             enableDebug: true
         }];
@@ -437,7 +437,7 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Store original log function
             const originalLog = n1.log;
             let logMessages = [];
@@ -445,33 +445,33 @@ describe('viessmann-config Node', function() {
                 logMessages.push(msg);
                 originalLog.call(n1, msg);
             };
-            
+
             n1.getValidToken().then(() => {
                 const debugLogs = logMessages.filter(msg => msg.includes('[DEBUG]'));
-                
+
                 // Should have debug message about checking token validity
                 const hasCheckMsg = debugLogs.some(msg => msg.includes('Checking token validity'));
                 expect(hasCheckMsg).to.be.true;
-                
+
                 done();
             }).catch(done);
         });
     });
 
     it('should update auth state to authenticated on successful authentication', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = makeCredentials('n1');
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // With tokens provided, auth state should be authenticated on load
             expect(n1.authState).to.equal('authenticated');
-            
+
             n1.authenticate().then(() => {
                 expect(n1.authState).to.equal('authenticated');
                 expect(n1.authError).to.be.null;
@@ -481,9 +481,9 @@ describe('viessmann-config Node', function() {
     });
 
     it('should update auth state to error on authentication failure', function(done) {
-        const flow = [{ 
-            id: 'n1', 
-            type: 'viessmann-config', 
+        const flow = [{
+            id: 'n1',
+            type: 'viessmann-config',
             name: 'test config'
         }];
         const credentials = {
@@ -495,7 +495,7 @@ describe('viessmann-config Node', function() {
 
         helper.load(configNode, flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.authenticate().then(() => {
                 done(new Error('Should have failed authentication'));
             }).catch(() => {

--- a/test/viessmann-device-features_spec.js
+++ b/test/viessmann-device-features_spec.js
@@ -119,7 +119,7 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -137,7 +137,7 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -155,7 +155,7 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -173,10 +173,10 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             let errorCount = 0;
             const expectedErrors = 5;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === expectedErrors) {
@@ -202,10 +202,10 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             let errorCount = 0;
             const expectedErrors = 3;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === expectedErrors) {
@@ -229,10 +229,10 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             let errorCount = 0;
             const expectedErrors = 3;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === expectedErrors) {
@@ -263,7 +263,7 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -279,7 +279,7 @@ describe('viessmann-device-features Node', function() {
 
         helper.load([configNode, deviceFeaturesNode], flow, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -298,7 +298,7 @@ describe('viessmann-device-features Node', function() {
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -306,17 +306,17 @@ describe('viessmann-device-features Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update
             c1.authenticate().then(() => {
                 // Should have updated status
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be green/connected
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('green');
                 expect(lastStatus.text).to.equal('connected');
-                
+
                 done();
             }).catch(done);
         });
@@ -337,7 +337,7 @@ describe('viessmann-device-features Node', function() {
         helper.load([configNode, deviceFeaturesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -345,16 +345,16 @@ describe('viessmann-device-features Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update (will fail)
             c1.authenticate().catch(() => {
                 // Should have updated status to error
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be red/error
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('red');
-                
+
                 done();
             });
         });

--- a/test/viessmann-device-list_spec.js
+++ b/test/viessmann-device-list_spec.js
@@ -194,7 +194,7 @@ describe('viessmann-device-list Node', function() {
 
         helper.load([configNode, deviceListNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -210,7 +210,7 @@ describe('viessmann-device-list Node', function() {
 
         helper.load([configNode, deviceListNode], flow, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -229,7 +229,7 @@ describe('viessmann-device-list Node', function() {
         helper.load([configNode, deviceListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -237,17 +237,17 @@ describe('viessmann-device-list Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update
             c1.authenticate().then(() => {
                 // Should have updated status
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be green/connected
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('green');
                 expect(lastStatus.text).to.equal('connected');
-                
+
                 done();
             }).catch(done);
         });
@@ -268,7 +268,7 @@ describe('viessmann-device-list Node', function() {
         helper.load([configNode, deviceListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -276,16 +276,16 @@ describe('viessmann-device-list Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update (will fail)
             c1.authenticate().catch(() => {
                 // Should have updated status to error
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be red/error
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('red');
-                
+
                 done();
             });
         });

--- a/test/viessmann-gateway-devices_spec.js
+++ b/test/viessmann-gateway-devices_spec.js
@@ -106,7 +106,7 @@ describe('viessmann-gateway-devices Node', function() {
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -124,7 +124,7 @@ describe('viessmann-gateway-devices Node', function() {
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -142,10 +142,10 @@ describe('viessmann-gateway-devices Node', function() {
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             let errorCount = 0;
             const expectedErrors = 5;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === expectedErrors) {
@@ -171,10 +171,10 @@ describe('viessmann-gateway-devices Node', function() {
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             let errorCount = 0;
             const expectedErrors = 3;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === expectedErrors) {
@@ -205,7 +205,7 @@ describe('viessmann-gateway-devices Node', function() {
 
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -221,7 +221,7 @@ describe('viessmann-gateway-devices Node', function() {
 
         helper.load([configNode, gatewayDevicesNode], flow, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -240,7 +240,7 @@ describe('viessmann-gateway-devices Node', function() {
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -248,17 +248,17 @@ describe('viessmann-gateway-devices Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update
             c1.authenticate().then(() => {
                 // Should have updated status
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be green/connected
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('green');
                 expect(lastStatus.text).to.equal('connected');
-                
+
                 done();
             }).catch(done);
         });
@@ -279,7 +279,7 @@ describe('viessmann-gateway-devices Node', function() {
         helper.load([configNode, gatewayDevicesNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -287,16 +287,16 @@ describe('viessmann-gateway-devices Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update (will fail)
             c1.authenticate().catch(() => {
                 // Should have updated status to error
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be red/error
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('red');
-                
+
                 done();
             });
         });

--- a/test/viessmann-gateway-list_spec.js
+++ b/test/viessmann-gateway-list_spec.js
@@ -106,7 +106,7 @@ describe('viessmann-gateway-list Node', function() {
 
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -124,10 +124,10 @@ describe('viessmann-gateway-list Node', function() {
 
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             let errorCount = 0;
             const expectedErrors = 5;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === expectedErrors) {
@@ -160,7 +160,7 @@ describe('viessmann-gateway-list Node', function() {
 
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -176,7 +176,7 @@ describe('viessmann-gateway-list Node', function() {
 
         helper.load([configNode, gatewayListNode], flow, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -195,7 +195,7 @@ describe('viessmann-gateway-list Node', function() {
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -203,17 +203,17 @@ describe('viessmann-gateway-list Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update
             c1.authenticate().then(() => {
                 // Should have updated status
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be green/connected
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('green');
                 expect(lastStatus.text).to.equal('connected');
-                
+
                 done();
             }).catch(done);
         });
@@ -234,7 +234,7 @@ describe('viessmann-gateway-list Node', function() {
         helper.load([configNode, gatewayListNode], flow, credentials, function() {
             const c1 = helper.getNode('c1');
             const n1 = helper.getNode('n1');
-            
+
             // Track status updates
             let statusCalls = [];
             const originalStatus = n1.status;
@@ -242,16 +242,16 @@ describe('viessmann-gateway-list Node', function() {
                 statusCalls.push(status);
                 originalStatus.call(n1, status);
             };
-            
+
             // Authenticate to trigger status update (will fail)
             c1.authenticate().catch(() => {
                 // Should have updated status to error
                 expect(statusCalls.length).to.be.greaterThan(0);
-                
+
                 // Last status should be red/error
                 const lastStatus = statusCalls[statusCalls.length - 1];
                 expect(lastStatus.fill).to.equal('red');
-                
+
                 done();
             });
         });

--- a/test/viessmann-read_spec.js
+++ b/test/viessmann-read_spec.js
@@ -69,9 +69,9 @@ describe('viessmann-read Node', function() {
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.temperature'
             });
@@ -181,9 +181,9 @@ describe('viessmann-read Node', function() {
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0'
             });
         });
@@ -198,7 +198,7 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -216,7 +216,7 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -234,7 +234,7 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
@@ -252,7 +252,7 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Test various invalid inputs: string, alphanumeric, negative, zero, float
             const invalidInputs = [
                 { installationId: 'invalid', gatewaySerial: '1234567890123456', deviceId: '0' },
@@ -261,9 +261,9 @@ describe('viessmann-read Node', function() {
                 { installationId: 0, gatewaySerial: '1234567890123456', deviceId: '0' },
                 { installationId: 1.5, gatewaySerial: '1234567890123456', deviceId: '0' }
             ];
-            
+
             let errorCount = 0;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === invalidInputs.length) {
@@ -284,7 +284,7 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Test various invalid inputs: number, empty string, whitespace-only, null
             const invalidInputs = [
                 { installationId: 123456, gatewaySerial: 12345, deviceId: '0' },
@@ -292,9 +292,9 @@ describe('viessmann-read Node', function() {
                 { installationId: 123456, gatewaySerial: '   ', deviceId: '0' },
                 { installationId: 123456, gatewaySerial: null, deviceId: '0' }
             ];
-            
+
             let errorCount = 0;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === invalidInputs.length) {
@@ -315,7 +315,7 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             // Test various invalid inputs: number, empty string, whitespace-only, null
             const invalidInputs = [
                 { installationId: 123456, gatewaySerial: '1234567890123456', deviceId: 12345 },
@@ -323,9 +323,9 @@ describe('viessmann-read Node', function() {
                 { installationId: 123456, gatewaySerial: '1234567890123456', deviceId: '   ' },
                 { installationId: 123456, gatewaySerial: '1234567890123456', deviceId: null }
             ];
-            
+
             let errorCount = 0;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === invalidInputs.length) {
@@ -353,14 +353,14 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0'
             });
         });
@@ -593,9 +593,9 @@ describe('viessmann-read Node', function() {
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.temperature'
             });
@@ -642,22 +642,22 @@ describe('viessmann-read Node', function() {
                     expect(msg.payload).to.have.property('feature', 'heating.circuits.0.temperature');
                     expect(msg.payload.properties.value).to.have.property('value', 21.5);
                     expect(msg.payload.properties.value).to.have.property('unit', 'celsius');
-                    
+
                     // Check that status was set with value and unit
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', '21.5celsius');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.temperature'
             });
@@ -702,22 +702,22 @@ describe('viessmann-read Node', function() {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload).to.have.property('feature', 'heating.circuits.0.operating.modes.active');
                     expect(msg.payload.properties.value).to.have.property('value', 'dhw');
-                    
+
                     // Check that status was set with value only
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', 'dhw');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active'
             });
@@ -763,22 +763,22 @@ describe('viessmann-read Node', function() {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload).to.have.property('feature', 'device.status');
                     expect(msg.payload.properties.status).to.have.property('value', 'OK');
-                    
+
                     // Check that status was set with value from properties.status
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', 'OK');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'device.status'
             });
@@ -823,22 +823,22 @@ describe('viessmann-read Node', function() {
                 try {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload).to.have.property('feature', 'heating.circuits.0.temperature');
-                    
+
                     // Check that status was set to success when value is null
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', 'success');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.temperature'
             });
@@ -885,22 +885,22 @@ describe('viessmann-read Node', function() {
                 try {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload).to.be.an('array');
-                    
+
                     // Check that status was set to success for all features read
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', 'success');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0'
             });
         });
@@ -937,14 +937,14 @@ describe('viessmann-read Node', function() {
 
         helper.load([configNode, readNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.temperature'
             });
@@ -988,22 +988,22 @@ describe('viessmann-read Node', function() {
                 try {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload.properties.strength).to.have.property('value', 75);
-                    
+
                     // Check that status was set with strength value
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', '75');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.burner.strength'
             });
@@ -1047,22 +1047,22 @@ describe('viessmann-read Node', function() {
                 try {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload.properties.active).to.have.property('value', true);
-                    
+
                     // Check that status was set with active value
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', 'true');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.active'
             });
@@ -1108,22 +1108,22 @@ describe('viessmann-read Node', function() {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload.properties.hours).to.have.property('value', 1234.5);
                     expect(msg.payload.properties.hours).to.have.property('unit', 'hour');
-                    
+
                     // Check that status was set with hours value and unit
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', '1234.5hour');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.burner.statistics'
             });
@@ -1167,22 +1167,22 @@ describe('viessmann-read Node', function() {
                 try {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload.properties.starts).to.have.property('value', 5678);
-                    
+
                     // Check that status was set with starts value
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', '5678');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.burner.starts'
             });
@@ -1228,22 +1228,22 @@ describe('viessmann-read Node', function() {
                     expect(msg).to.have.property('payload');
                     expect(msg.payload.properties.temperature).to.have.property('value', 65.5);
                     expect(msg.payload.properties.temperature).to.have.property('unit', 'celsius');
-                    
+
                     // Check that status was set with temperature value and unit
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', '65.5celsius');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.boiler.temperature'
             });
@@ -1294,22 +1294,22 @@ describe('viessmann-read Node', function() {
                     expect(msg.payload.properties.hours).to.have.property('value', 1234.5);
                     expect(msg.payload.properties.hours).to.have.property('unit', 'hour');
                     expect(msg.payload.properties.starts).to.have.property('value', 5678);
-                    
+
                     // Check that status shows both values concatenated with /
                     const status = n1.status.lastCall.args[0];
                     expect(status).to.have.property('fill', 'green');
                     expect(status).to.have.property('shape', 'dot');
                     expect(status).to.have.property('text', '1234.5hour/5678');
-                    
+
                     done();
                 } catch (err) {
                     done(err);
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.burner.statistics'
             });

--- a/test/viessmann-write_spec.js
+++ b/test/viessmann-write_spec.js
@@ -49,9 +49,9 @@ describe('viessmann-write Node', function() {
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -87,9 +87,9 @@ describe('viessmann-write Node', function() {
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 datapoint: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -200,13 +200,13 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -224,13 +224,13 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
+            n1.receive({
+                installationId: 123456,
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -248,13 +248,13 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
+            n1.receive({
+                installationId: 123456,
                 gatewaySerial: '1234567890123456',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -272,13 +272,13 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
+            n1.receive({
+                installationId: 123456,
                 gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 command: 'setMode',
@@ -296,13 +296,13 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
+            n1.receive({
+                installationId: 123456,
                 gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
@@ -320,13 +320,13 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
+            n1.receive({
+                installationId: 123456,
                 gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
@@ -381,9 +381,9 @@ describe('viessmann-write Node', function() {
                 { installationId: 0, gatewaySerial: '1234567890123456', deviceId: '0', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } },
                 { installationId: 1.5, gatewaySerial: '1234567890123456', deviceId: '0', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } }
             ];
-            
+
             let errorCount = 0;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === invalidInputs.length) {
@@ -404,16 +404,16 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             const invalidInputs = [
                 { installationId: 123456, gatewaySerial: 12345, deviceId: '0', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } },
                 { installationId: 123456, gatewaySerial: '', deviceId: '0', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } },
                 { installationId: 123456, gatewaySerial: '   ', deviceId: '0', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } },
                 { installationId: 123456, gatewaySerial: null, deviceId: '0', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } }
             ];
-            
+
             let errorCount = 0;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === invalidInputs.length) {
@@ -434,16 +434,16 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             const invalidInputs = [
                 { installationId: 123456, gatewaySerial: '1234567890123456', deviceId: 12345, feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } },
                 { installationId: 123456, gatewaySerial: '1234567890123456', deviceId: '', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } },
                 { installationId: 123456, gatewaySerial: '1234567890123456', deviceId: '   ', feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } },
                 { installationId: 123456, gatewaySerial: '1234567890123456', deviceId: null, feature: 'heating.circuits.0.operating.modes.active', command: 'setMode', params: { mode: 'dhw' } }
             ];
-            
+
             let errorCount = 0;
-            
+
             n1.on('call:error', function() {
                 errorCount++;
                 if (errorCount === invalidInputs.length) {
@@ -471,14 +471,14 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -494,14 +494,14 @@ describe('viessmann-write Node', function() {
 
         helper.load([writeNode], flow, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -631,9 +631,9 @@ describe('viessmann-write Node', function() {
                 }
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',
@@ -673,14 +673,14 @@ describe('viessmann-write Node', function() {
 
         helper.load([configNode, writeNode], flow, credentials, function() {
             const n1 = helper.getNode('n1');
-            
+
             n1.on('call:error', function() {
                 done();
             });
 
-            n1.receive({ 
-                installationId: 123456, 
-                gatewaySerial: '1234567890123456', 
+            n1.receive({
+                installationId: 123456,
+                gatewaySerial: '1234567890123456',
                 deviceId: '0',
                 feature: 'heating.circuits.0.operating.modes.active',
                 command: 'setMode',


### PR DESCRIPTION
Closes #95.

## Summary
- eslint.config.js gains `no-trailing-spaces`, `no-multiple-empty-lines` (max 2), and `eol-last` (require final newline).
- `eslint --fix` applied across nodes/, scripts/, test/. The diff is whitespace-only; no logic change.

## Internal multi-perspective review
- **Code quality** — direct fix; future trailing-whitespace edits caught by lint.
- **Architecture** — n/a.
- **Security** — n/a.
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean (rules satisfied)
- [x] `npm test` — 221 passing (unchanged)