### PR TITLE
Unify debug logging through config.debugLog (#96)

### DIFF
--- a/nodes/lib/node-runtime.js
+++ b/nodes/lib/node-runtime.js
@@ -140,7 +140,7 @@ async function executeApiGet(node, msg, url, statusText = 'fetching...', errorPr
     const controller = trackAbortController(node);
     try {
         node.status({fill: 'yellow', shape: 'ring', text: statusText});
-        node.debug(`Executing GET ${url}`);
+        node.config.debugLog(`Executing GET ${url}`);
         const response = await node.config.client.get(url, {
             onRetryWait: statusRetryReporter(node, statusText),
             signal: controller.signal
@@ -174,7 +174,7 @@ async function executeApiPost(node, msg, url, data, statusText = 'writing...', e
     const controller = trackAbortController(node);
     try {
         node.status({fill: 'yellow', shape: 'ring', text: statusText});
-        node.debug(`Executing POST ${url} with data: ${safeStringifyForDebug(data)}`);
+        node.config.debugLog(`Executing POST ${url} with data: ${safeStringifyForDebug(data)}`);
         const response = await node.config.client.post(url, data, {
             onRetryWait: statusRetryReporter(node, statusText),
             signal: controller.signal

--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -78,7 +78,10 @@ module.exports = function(RED) {
         this.client = new ViessmannClient(node, clientOptions);
 
         /**
-         * Log debug information if debug mode is enabled
+         * Log debug information if debug mode is enabled. Exposed as
+         * `node.debugLog` so consumer nodes (via node-runtime) can route
+         * their debug output through the same toggle - one "Enable Debug
+         * Logging" checkbox controls everything.
          * @param {string} message - The debug message to log
          */
         const debugLog = function(message) {
@@ -86,6 +89,7 @@ module.exports = function(RED) {
                 node.log('[DEBUG] ' + message);
             }
         };
+        this.debugLog = debugLog;
 
         /**
          * Update authentication state and notify subscribers via the

--- a/test/viessmann-helpers_spec.js
+++ b/test/viessmann-helpers_spec.js
@@ -571,6 +571,36 @@ describe('viessmann-helpers', function() {
         });
     });
 
+    describe('debug-log routing through config.debugLog', function() {
+        let node;
+        const msg = { _msgid: 'debug-test' };
+
+        beforeEach(function() {
+            node = {
+                config: {
+                    debugLog: sinon.stub(),
+                    client: { get: sinon.stub().resolves({ data: { data: [] } }), post: sinon.stub().resolves({ data: { data: {} } }) }
+                },
+                status: sinon.stub(),
+                error: sinon.stub(),
+                send: sinon.stub(),
+                _inflightAbortControllers: new Set()
+            };
+        });
+
+        it('executeApiGet routes "Executing GET ..." through config.debugLog', async function() {
+            await executeApiGet(node, msg, 'https://example.test/x');
+            expect(node.config.debugLog.calledOnce).to.equal(true);
+            expect(node.config.debugLog.firstCall.args[0]).to.include('Executing GET');
+        });
+
+        it('executeApiPost routes "Executing POST ..." through config.debugLog', async function() {
+            await executeApiPost(node, msg, 'https://example.test/x', { a: 1 });
+            expect(node.config.debugLog.calledOnce).to.equal(true);
+            expect(node.config.debugLog.firstCall.args[0]).to.include('Executing POST');
+        });
+    });
+
     describe('executeApiGet / executeApiPost missing-config guard', function() {
         let node;
         const msg = { _msgid: 'guard-test' };


### PR DESCRIPTION
Closes #96.

## Summary
- `viessmann-config` exposes its `debugLog` as `node.debugLog` (was a private const).
- `executeApiGet` / `executeApiPost` in `node-runtime.js` now use `node.config.debugLog(...)` instead of `node.debug(...)`. One toggle controls everything.

## Why
The "Enable Debug Logging" checkbox previously had no effect on the GET/POST trace lines — those used Node-RED's `node.debug` log-level system, gated separately. Users enabled the flag and saw no extra output.

## Internal multi-perspective review
- **Code quality** — single channel.
- **Architecture** — n/a.
- **Security** — n/a (the existing token-mask redaction is unchanged).
- **Error handling** — n/a.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 221 passing