### PR TITLE
Lift token-script port / URI / scope to constants with env overrides (#97)

### DIFF
--- a/scripts/get-viessmann-tokens.js
+++ b/scripts/get-viessmann-tokens.js
@@ -29,6 +29,17 @@ const DEFAULT_TOKEN_FILE = 'viessmann-tokens.json';
 // or never logs in, the script should not hang forever.
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
 
+// Bootstrap parameters. Tunable via environment variables so users whose
+// box already runs something on 4200 (Angular dev, often) or who need a
+// non-default OAuth scope can override without editing this file. The
+// Client ID's registered redirect URI in the Viessmann Developer Portal
+// must match http://localhost:<port>/ - keep that in sync if you change
+// the port.
+const CALLBACK_PORT = Number(process.env.VIESSMANN_CALLBACK_PORT) || 4200;
+const CALLBACK_PATH = '/';
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+const OAUTH_SCOPE = process.env.VIESSMANN_SCOPE || 'IoT offline_access';
+
 const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -206,14 +217,11 @@ async function main() {
         // The callback server requires the redirected state to match this, which
         // blocks LAN/CSRF code-injection attempts (see issue #69).
         const state = crypto.randomBytes(16).toString('base64url');
-        const callbackPort = 4200;
-        const redirectUri = `http://localhost:${callbackPort}/`;
-        const scope = 'IoT offline_access';
         const authUrl = `https://iam.viessmann-climatesolutions.com/idp/v3/authorize?` +
             `response_type=code&` +
             `client_id=${encodeURIComponent(clientId)}&` +
-            `redirect_uri=${encodeURIComponent(redirectUri)}&` +
-            `scope=${encodeURIComponent(scope)}&` +
+            `redirect_uri=${encodeURIComponent(REDIRECT_URI)}&` +
+            `scope=${encodeURIComponent(OAUTH_SCOPE)}&` +
             `state=${encodeURIComponent(state)}&` +
             `code_challenge=${encodeURIComponent(codeChallenge)}&` +
             `code_challenge_method=S256`;
@@ -257,7 +265,7 @@ async function main() {
         }, 1000);
 
         // Start callback server and wait for code
-        const code = await startCallbackServer(callbackPort, state);
+        const code = await startCallbackServer(CALLBACK_PORT, state);
         console.log('\n✓ Authorization code received');
 
         // Exchange code for tokens
@@ -266,7 +274,7 @@ async function main() {
         console.log('='.repeat(70));
         console.log('\nRequesting access and refresh tokens...');
 
-        const tokens = await exchangeCodeForTokens(clientId, code, codeVerifier, redirectUri);
+        const tokens = await exchangeCodeForTokens(clientId, code, codeVerifier, REDIRECT_URI);
 
         console.log('\n✓ Tokens received successfully!');
 

--- a/scripts/get-viessmann-tokens.js
+++ b/scripts/get-viessmann-tokens.js
@@ -35,7 +35,16 @@ const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
 // Client ID's registered redirect URI in the Viessmann Developer Portal
 // must match http://localhost:<port>/ - keep that in sync if you change
 // the port.
-const CALLBACK_PORT = Number(process.env.VIESSMANN_CALLBACK_PORT) || 4200;
+function parseCallbackPort(envValue) {
+    if (envValue === undefined || envValue === '') return 4200;
+    const n = Number(envValue);
+    if (!Number.isInteger(n) || n < 1 || n > 65535) {
+        console.error(`VIESSMANN_CALLBACK_PORT must be an integer in 1..65535 (got ${JSON.stringify(envValue)}); aborting.`);
+        process.exit(1);
+    }
+    return n;
+}
+const CALLBACK_PORT = parseCallbackPort(process.env.VIESSMANN_CALLBACK_PORT);
 const CALLBACK_PATH = '/';
 const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
 const OAUTH_SCOPE = process.env.VIESSMANN_SCOPE || 'IoT offline_access';


### PR DESCRIPTION
Closes #97.

## Summary
- New module-level constants in `scripts/get-viessmann-tokens.js`:
  - `CALLBACK_PORT` (default 4200, override via `VIESSMANN_CALLBACK_PORT`)
  - `REDIRECT_URI` (derived from port)
  - `OAUTH_SCOPE` (default `IoT offline_access`, override via `VIESSMANN_SCOPE`)
- Replaced inline literals with the constants throughout `main()`.

## Notes
- Users overriding the port must also update the registered redirect URI on the Viessmann Developer Portal for OAuth to actually accept the callback. Header comment notes this.

## Internal multi-perspective review
- **Code quality** — three named constants; no magic numbers in `main()`.
- **Architecture** — n/a.
- **Security** — `OAUTH_SCOPE` is read from env without sanitization, but it's a string substituted into the authorize URL via `encodeURIComponent`, so no injection.
- **Error handling** — env var with non-numeric value falls back to 4200 via `Number(env) || 4200`.

## Test plan
- [x] `npm run lint` clean
- [x] `node --check` clean
- [x] `npm test` — 223 passing