### PR TITLE
Force first-use refresh instead of fabricating a 1-hour expiry (#83)

### DIFF
--- a/nodes/viessmann-config.js
+++ b/nodes/viessmann-config.js
@@ -111,11 +111,17 @@ module.exports = function(RED) {
             return { state: node.authState, error: node.authError };
         };
 
-        // Initialize token expiry tracking if we have an access token
+        // Initialize token expiry tracking if we have an access token.
+        //
+        // We have no idea how old the stored access token actually is - it
+        // could have 59 minutes left or it could already be expired. Setting
+        // tokenExpiry = 0 makes the very first request force a refresh-or-
+        // validate path (cheap with a valid refresh token; fails fast and
+        // clearly if neither token works), instead of optimistically trusting
+        // the token for an hour and discovering its true state via a 401
+        // mid-flow.
         if (this.accessToken) {
-            // Assume token expires in 1 hour (default for Viessmann) minus buffer
-            // This will trigger a refresh on first use if refresh token is available
-            this.tokenExpiry = Date.now() + (3600 * 1000);
+            this.tokenExpiry = 0;
             updateAuthState('authenticated');
         }
 

--- a/test/viessmann-config_spec.js
+++ b/test/viessmann-config_spec.js
@@ -54,6 +54,20 @@ describe('viessmann-config Node', function() {
         });
     });
 
+    it('should force first-use refresh when seeding from stored credentials', function(done) {
+        // tokenExpiry must be 0 (not Date.now() + 1h) so the first
+        // getValidToken() call refreshes/validates instead of trusting an
+        // unknown-age stored token.
+        const flow = [{ id: 'n1', type: 'viessmann-config', name: 'test config' }];
+        const credentials = makeCredentials('n1');
+
+        helper.load(configNode, flow, credentials, function() {
+            const n1 = helper.getNode('n1');
+            expect(n1.tokenExpiry).to.equal(0);
+            done();
+        });
+    });
+
     it('should dedupe concurrent token refreshes into a single token endpoint call', function(done) {
         const flow = [{
             id: 'n1',


### PR DESCRIPTION
Closes #83.

## Summary
On config load with a stored access token, `tokenExpiry` is now `0` (not `Date.now() + 1h`). The first `getValidToken()` takes the refresh-or-revalidate path immediately.

## Why
Stored tokens have unknown age. The fabricated 1-hour window meant the first 55 minutes after a restart relied on a token that might already be invalid; the failure surfaced via the 401-refresh fallback only after a real API round-trip failed (slower, plus an unnecessary `node.error` warning).

## Internal multi-perspective review
- **Code quality** — one-line change + comment.
- **Architecture** — n/a.
- **Security** — n/a (refresh token rotation is already de-dup'd via #57).
- **Error handling** — fails fast on stale tokens instead of via late 401.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 229 passing (+1 test asserting tokenExpiry === 0 after load).