### PR TITLE
Drop dev-only docs from published tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ The Viessmann API exposes hundreds of features organised under `device.*`, `gate
 
 ## Development
 
-- Setup, coding standards, PR process → [CONTRIBUTING.md](CONTRIBUTING.md)
-- Test framework, fixtures, coverage → [test/README.md](test/README.md)
+These docs live on GitHub (not shipped to npm to keep the published
+tarball small):
+
+- Setup, coding standards, PR process → [CONTRIBUTING.md](https://github.com/pkot/node-red-contrib-viessmann/blob/main/CONTRIBUTING.md)
+- Test framework, fixtures, coverage → [test/README.md](https://github.com/pkot/node-red-contrib-viessmann/blob/main/test/README.md)
 - Token bootstrap CLI details → [scripts/README.md](scripts/README.md)
-- Intent and architecture decisions → [SPEC.md](SPEC.md)
-- Conventions / patterns for coding agents → [AGENTS.md](AGENTS.md)
+- Intent and architecture decisions → [SPEC.md](https://github.com/pkot/node-red-contrib-viessmann/blob/main/SPEC.md)
+- Conventions / patterns for coding agents → [AGENTS.md](https://github.com/pkot/node-red-contrib-viessmann/blob/main/AGENTS.md)
 
 ## Building from source
 
@@ -118,4 +121,4 @@ Paweł Kot
 
 ## Contributing
 
-Bug reports, feature requests, and pull requests welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
+Bug reports, feature requests, and pull requests welcome. See [CONTRIBUTING.md](https://github.com/pkot/node-red-contrib-viessmann/blob/main/CONTRIBUTING.md) for the workflow.

--- a/package.json
+++ b/package.json
@@ -12,12 +12,8 @@
     "nodes/",
     "examples/",
     "scripts/",
-    "test/README.md",
     "LICENSE",
-    "README.md",
-    "AGENTS.md",
-    "CONTRIBUTING.md",
-    "SPEC.md"
+    "README.md"
   ],
   "bin": {
     "viessmann-get-tokens": "scripts/get-viessmann-tokens.js"


### PR DESCRIPTION
## Summary
`CONTRIBUTING.md`, `SPEC.md`, `AGENTS.md`, and `test/README.md` are contributor and agent docs — they don't belong in the tarball npm consumers download. Removed from `package.json#files`.

README's four links to those files were switched to absolute GitHub URLs so they still resolve from the npmjs.com README rendering. In-repo viewing on GitHub is unaffected (the rendered README finds them either way).

## Tarball before / after

| Was shipped | Now shipped |
|---|---|
| README.md, AGENTS.md, CONTRIBUTING.md, SPEC.md, FEATURES.md (×already removed), test/README.md, nodes/README.md, examples/README.md, scripts/README.md | README.md, nodes/README.md, examples/README.md, scripts/README.md |

~25 kB of contributor docs no longer in the tarball.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 228 passing
- [x] `npm pack --dry-run` includes only the four user-facing `.md` files
- [x] All README links resolve (absolute URLs for dev docs, relative for user-facing)