### PR TITLE
ci: drop Codecov upload and test-result archiving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,22 +46,3 @@ jobs:
 
     - name: Run tests (with coverage via c8)
       run: npm test
-      
-    - name: Upload coverage to Codecov
-      if: contains(fromJson('["20.x","22.x","24.x"]'), matrix.node-version)
-      # Real lcov.info is now produced by `npm test` via c8 (was a no-op when
-      # the path didn't exist).
-      uses: codecov/codecov-action@v6
-      with:
-        files: ./coverage/lcov.info
-        fail_ci_if_error: false
-        
-    - name: Archive test results
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: test-results-${{ matrix.node-version }}
-        path: |
-          coverage/
-          *.log
-        retention-days: 7

--- a/test/README.md
+++ b/test/README.md
@@ -41,8 +41,7 @@ npx c8 mocha test/viessmann-read_spec.js       # one file with coverage
 | Lines | 70% |
 
 Current numbers are well above (94 / 87 / 96 / 94 as of this writing).
-`coverage/lcov.info` is generated for Codecov; `coverage/index.html` is the
-local browse-able report.
+`coverage/index.html` is the local browse-able report.
 
 ## Layout
 


### PR DESCRIPTION
## Summary

- Drops the **Upload coverage to Codecov** step — no \`codecov.yml\`, no \`CODECOV_TOKEN\`, no badge in README, so nothing consumed the upload. The 70% coverage gate is already enforced locally by \`.c8rc.json\` (\`npm test\` fails if it drops).
- Drops the **Archive test results** step — \`*.log\` doesn't exist in CI, and green-run coverage artifacts aren't useful debugging material; on failure the workflow log already has the mocha output.
- Removes the stale \"generated for Codecov\" line from test/README.md.

If we want Codecov dashboards or PR comments later, add a \`codecov.yml\` + README badge and reintroduce the upload step then.

## Test plan
- [ ] CI green on this PR (the two steps removed are post-test, so test/lint behavior is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)